### PR TITLE
fix: correct bot username from @gitghost-anonymous to @gitgost-anonym…

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ git remote add gost https://gitgost.leapcell.app/v1/gh/torvalds/linux
 git checkout -b fix-typo
 git commit -am "fix: obvious typo in README"
 git push gost fix-typo:main
-# → PR opened as @gitghost-anonymous with zero trace to you
+# → PR opened as @gitgost-anonymous with zero trace to you
 ```
 
 That’s it. No login. No token. No name. No email. No history.
@@ -27,7 +27,7 @@ That’s it. No login. No token. No name. No email. No history.
 
 | Feature                     | Description                                                                 |
 |-----------------------------|-----------------------------------------------------------------------------|
-| **Total Anonymity**         | Strips author name, email, timestamps, and all identifying metadata. PRs created by neutral `@gitghost-anonymous` bot. |
+| **Total Anonymity**         | Strips author name, email, timestamps, and all identifying metadata. PRs created by neutral `@gitgost-anonymous` bot. |
 | **One-Command Setup**       | Just `git remote add gost <url>` – no accounts, tokens, or browser extensions. |
 | **Battle-tested Security**  | Rate limiting, repository size caps, commit validation. Written in pure Go with minimal dependencies – fully auditable. |
 | **Works Everywhere**        | Terminal, CI/CD, Docker, scripts – any public GitHub repo, anywhere Git runs. |

--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -225,7 +225,7 @@ func ReceivePackHandler(c *gin.Context) {
 	WriteSidebandLine(&response, 2, "remote: ========================================")
 	WriteSidebandLine(&response, 2, "remote: ")
 	WriteSidebandLine(&response, 2, fmt.Sprintf("remote: PR URL: %s", prURL))
-	WriteSidebandLine(&response, 2, "remote: Author: @gitghost-anonymous")
+	WriteSidebandLine(&response, 2, "remote: Author: @gitgost-anonymous")
 	WriteSidebandLine(&response, 2, fmt.Sprintf("remote: Branch: %s", branch))
 	WriteSidebandLine(&response, 2, "remote: ")
 	WriteSidebandLine(&response, 2, "remote: Your identity has been anonymized.")


### PR DESCRIPTION
…ous in README and handler messages

Corregido typo consistente en nombre de usuario del bot anónimo en documentación y mensajes de respuesta Git. Actualizado README (ejemplos y tabla de features) y handler de receive-pack para usar @gitgost-anonymous en lugar de @gitghost-anonymous.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated anonymizing bot username in documentation and usage examples.

* **Chores**
  * Updated bot identifier in system messages to maintain consistency across documentation and output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->