### PR TITLE
feat: use commit message as PR description and improve test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,15 +93,20 @@ For more details, see [SECURITY.md](SECURITY.md).
 # 1. Add the remote (replace with any public repo)
 git remote add gost https://gitgost.leapcell.app/v1/gh/username/repo
 
-# 2. Create your branch and commit as usual
+# 2. Create your branch and commit with a detailed message
 git checkout -b my-cool-fix
-git commit -am "fix: something obvious"
+git commit -am "fix: typo in documentation
+
+This commit fixes a grammatical error in the README.
+The word 'recieve' should be 'receive'."
 
 # 3. Push – PR opens anonymously
 git push gost my-cool-fix:main
 ```
 
-Done. The PR appears instantly from `@ghost-contributor`.
+Done. The PR appears instantly from `@gitgost-anonymous` with your commit message as the PR description.
+
+**Pro tip:** Write detailed commit messages! Your commit message becomes the PR description, allowing you to provide context while staying anonymous.
 
 ## Security & Limits (we’re not reckless)
 

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -13,7 +13,7 @@ func TestCreatePR_NoToken(t *testing.T) {
 	// Remove token
 	os.Unsetenv("GITHUB_TOKEN")
 
-	_, err := CreatePR("owner", "repo", "branch", "forkowner")
+	_, err := CreatePR("owner", "repo", "branch", "forkowner", "test commit message")
 	if err == nil {
 		t.Error("Expected error when GITHUB_TOKEN is not set")
 	}

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -95,18 +95,21 @@ func ForkRepo(owner, repo string) (string, error) {
 	return forkOwner, nil
 }
 
-func CreatePR(owner, repo, branch, forkOwner string) (string, error) {
+func CreatePR(owner, repo, branch, forkOwner, commitMessage string) (string, error) {
 	token := os.Getenv("GITHUB_TOKEN")
 	if token == "" {
 		return "", fmt.Errorf("GITHUB_TOKEN not set")
 	}
 
 	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/pulls", owner, repo)
+
+	prBody := fmt.Sprintf("%s\n\n---\n\n*This is an anonymous contribution made via [gitGost](https://github.com/livrasand/gitGost).*\n\n*The original author's identity has been anonymized to protect their privacy.*", commitMessage)
+
 	data := map[string]interface{}{
 		"title": "Anonymous contribution via gitGost",
 		"head":  fmt.Sprintf("%s:%s", forkOwner, branch),
 		"base":  "main",
-		"body":  "This is an anonymous contribution made via [gitGost](https://github.com/livrasand/gitGost).\n\nThe original author's identity has been anonymized to protect their privacy.",
+		"body":  prBody,
 	}
 
 	jsonData, err := json.Marshal(data)

--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -156,7 +156,7 @@ func ReceivePackHandler(c *gin.Context) {
 	WriteSidebandLine(&response, 2, "remote: gitGost: Processing your anonymous contribution...")
 
 	// Procesar el packfile
-	newSHA, err := git.ReceivePack(tempDir, body, owner, repo)
+	newSHA, commitMessage, err := git.ReceivePack(tempDir, body, owner, repo)
 	if err != nil {
 		utils.Log("Error receiving pack: %v", err)
 		WriteSidebandLine(&response, 3, fmt.Sprintf("unpack error: %v", err))
@@ -200,7 +200,7 @@ func ReceivePackHandler(c *gin.Context) {
 
 	// Crear PR desde el fork al repo original
 	WriteSidebandLine(&response, 2, "remote: gitGost: Creating pull request...")
-	prURL, err := github.CreatePR(owner, repo, branch, forkOwner)
+	prURL, err := github.CreatePR(owner, repo, branch, forkOwner, commitMessage)
 	if err != nil {
 		utils.Log("Error creating PR: %v", err)
 		WriteSidebandLine(&response, 2, "unpack ok")


### PR DESCRIPTION
Modificado flujo para extraer mensaje del commit original y usarlo como descripción del PR. Actualizado ReceivePack() para retornar mensaje junto con SHA, agregado footer automático en CreatePR() identificando contribución anónima vía gitGost. Mejorados tests de ReceivePack para validar error cuando GITHUB_TOKEN no está configurado. Actualizado README con ejemplo de commit detallado y pro tip sobre mensajes descriptivos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  - Updated quick start guide to emphasize writing detailed commit messages
  - Added guidance that commit messages now populate PR descriptions

* **New Features**
  - Commit messages are now automatically captured and used as pull request descriptions, enabling contributors to provide meaningful context while maintaining anonymity

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->