### PR TITLE
Anonymous contribution via gitGost

### DIFF
--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -238,6 +238,10 @@ func ReceivePackHandler(c *gin.Context) {
 	WritePktLine(&response, "") // flush final
 
 	c.Writer.Write(response.Bytes())
+	c.Writer.Flush()
+
+	// Pequeño delay para permitir que Git procese la respuesta y cierre su lado primero
+	time.Sleep(100 * time.Millisecond)
 }
 
 // sendErrorResponse envía una respuesta de error en formato Git protocol


### PR DESCRIPTION
fix: add explicit flush and delay in ReceivePackHandler to prevent premature connection closure

Agregado Writer.Flush() explícito después de escribir respuesta Git protocol y delay de 100ms para permitir que Git cliente procese respuesta completa antes de cerrar conexión. Previene errores de "connection reset by peer" en push anónimo.


---

*This is an anonymous contribution made via [gitGost](https://github.com/livrasand/gitGost).*

*The original author's identity has been anonymized to protect their privacy.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Git communication by ensuring proper synchronization between client and server during pack operations, preventing potential communication issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->