### PR TITLE
Anonymous contribution via gitGost

### DIFF
--- a/internal/git/receive.go
+++ b/internal/git/receive.go
@@ -320,7 +320,7 @@ func rewriteCommit(r *git.Repository, commit *object.Commit, commitMap map[plumb
 
 	// Crear nuevo commit con información anonimizada
 	anonSignature := object.Signature{
-		Name:  "gitGost Anonymous",
+		Name:  "@gitgost-anonymous",
 		Email: "anonymous@gitgost.local",
 		When:  time.Now(),
 	}

--- a/internal/git/squash.go
+++ b/internal/git/squash.go
@@ -60,12 +60,12 @@ func SquashCommits(tempDir string) (string, error) {
 	// Create new anonymous commit
 	newCommit := &object.Commit{
 		Author: object.Signature{
-			Name:  "gitGost Anonymous",
+			Name:  "@gitgost-anonymous",
 			Email: "anon@gitgost",
 			When:  time.Now(),
 		},
 		Committer: object.Signature{
-			Name:  "gitGost Anonymous",
+			Name:  "@gitgost-anonymous",
 			Email: "anon@gitgost",
 			When:  time.Now(),
 		},


### PR DESCRIPTION
fix: standardize anonymous author name to @gitgost-anonymous in commit signatures

Actualizado nombre de autor anónimo de "gitGost Anonymous" a "@gitgost-anonymous" en rewriteCommit() y SquashCommits() para consistencia con username del bot y formato de menciones GitHub.


---

*This is an anonymous contribution made via [gitGost](https://github.com/livrasand/gitGost).*

*The original author's identity has been anonymized to protect their privacy.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the identifier format used for anonymized commits to a standardized naming convention.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->