### PR TITLE
Fix badge URLs for anonymous contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ That’s it. No login. No token. No name. No email. No history.
 
 To signal that your repository welcomes anonymous contributions via gitGost, add this badge to your README:
 
-![Anonymous Contributor Friendly](https://gitgost.io/badges/anonymous-friendly.svg)
+![Anonymous Contributor Friendly](https://gitgost.leapcell.app/badges/anonymous-friendly.svg)
 
 
 For verified repositories, add a `.gitgost.yml` file to your repository root and use the dynamic version:
 
-![Anonymous Contributor Friendly](https://gitgost.io/badges/anonymous-friendly.svg?repo=livrasand/gitGost)
+![Anonymous Contributor Friendly](https://gitgost.leapcell.app/badges/anonymous-friendly.svg?repo=livrasand%2FgitGost)
 
 This badge helps contributors know that anonymous contributions are accepted and encouraged.
 


### PR DESCRIPTION
Updated badge URLs for anonymous contributor friendly badge in README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project documentation badge URLs to a new domain.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->