### PR TITLE
fix: add WWW-Authenticate header to upload-pack discovery to prevent …

### DIFF
--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -288,6 +288,7 @@ func UploadPackDiscoveryHandler(c *gin.Context) {
 	defer resp.Body.Close()
 
 	c.Writer.Header().Set("Content-Type", "application/x-git-upload-pack-advertisement")
+	c.Writer.Header().Set("WWW-Authenticate", "None")
 	c.Writer.WriteHeader(resp.StatusCode)
 	if _, err := io.Copy(c.Writer, resp.Body); err != nil {
 		utils.Log("UploadPackDiscovery copy error (status %d): %v", resp.StatusCode, err)


### PR DESCRIPTION
…auth prompts

Agregado header WWW-Authenticate: None en UploadPackDiscoveryHandler para evitar que clientes Git soliciten autenticación innecesaria durante git-upload-pack advertisement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated HTTP header handling for authentication protocol compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->