### PR TITLE
fix: add 401 authentication challenge to upload-pack handlers and upd…

### DIFF
--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -279,6 +279,13 @@ func UploadPackDiscoveryHandler(c *gin.Context) {
 	req.Header.Set("Authorization", "Basic "+basicAuth("x-access-token", token))
 	req.Header.Set("User-Agent", "git/2.0")
 
+	// Si Git llega sin Authorization, responder 401 para que negocie credenciales.
+	if c.GetHeader("Authorization") == "" {
+		c.Writer.Header().Set("WWW-Authenticate", `Basic realm="gitgost"`)
+		c.Writer.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
 	resp, err := uploadPackClient.Do(req)
 	if err != nil {
 		utils.Log("UploadPackDiscovery error: %v", err)
@@ -334,6 +341,13 @@ func UploadPackHandler(c *gin.Context) {
 		return
 	}
 	defer resp.Body.Close()
+
+	// Si Git llega sin Authorization, responder 401 para que negocie credenciales.
+	if c.GetHeader("Authorization") == "" {
+		c.Writer.Header().Set("WWW-Authenticate", `Basic realm="gitgost"`)
+		c.Writer.WriteHeader(http.StatusUnauthorized)
+		return
+	}
 
 	c.Writer.Header().Set("Content-Type", "application/x-git-upload-pack-result")
 	c.Writer.WriteHeader(resp.StatusCode)

--- a/web/index.html
+++ b/web/index.html
@@ -981,9 +981,10 @@ The word 'recieve' should be 'receive'."
 <span class="success">→</span> Anonymized commit + PR opened as @gitgost-anonymous</div>
             </div>
             <div class="terminal" id="terminal-fetch" style="display:none;"><div class="terminal-titlebar"><span class="terminal-btn close"></span><span class="terminal-btn min"></span><span class="terminal-btn max"></span></div><div class="terminal-body"><span class="comment"># Clone or fetch anonymously — no GitHub account needed.</span>
-<span class="prompt">$</span> git clone https://gitgost.leapcell.app/v1/gh/torvalds/linux
+<span class="comment"># Use anon: prefix to skip credential prompt</span>
+<span class="prompt">$</span> git clone https://anon:@gitgost.leapcell.app/v1/gh/torvalds/linux
 <span class="comment"># Or add as remote and fetch/pull later</span>
-<span class="prompt">$</span> git remote add gost https://gitgost.leapcell.app/v1/gh/torvalds/linux
+<span class="prompt">$</span> git remote add gost https://anon:@gitgost.leapcell.app/v1/gh/torvalds/linux
 <span class="prompt">$</span> git fetch gost
 <span class="prompt">$</span> git pull gost main
 <span class="success">→</span> Repository cloned with zero identity exposure</div>


### PR DESCRIPTION
…ate clone URLs with anon: prefix

Agregado header WWW-Authenticate con challenge 401 en UploadPackDiscoveryHandler y UploadPackHandler cuando falta Authorization para forzar negociación de credenciales. Actualizado ejemplo de clone/fetch en index.html con prefijo anon:@ en URLs para evitar prompts de autenticación innecesarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authentication requirement for Git operations; requests missing Authorization headers now return 401 Unauthorized to prompt credential entry.

* **Documentation**
  * Updated fetch/clone examples to demonstrate using anon-prefix URLs to bypass credential prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->