### PR TITLE
Remove GitHub token authentication and credential prompts from upload…

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -981,7 +981,6 @@ The word 'recieve' should be 'receive'."
 <span class="success">→</span> Anonymized commit + PR opened as @gitgost-anonymous</div>
             </div>
             <div class="terminal" id="terminal-fetch" style="display:none;"><div class="terminal-titlebar"><span class="terminal-btn close"></span><span class="terminal-btn min"></span><span class="terminal-btn max"></span></div><div class="terminal-body"><span class="comment"># Clone or fetch anonymously — no GitHub account needed.</span>
-<span class="comment"># Use anon: prefix to skip credential prompt</span>
 <span class="prompt">$</span> git clone https://anon:@gitgost.leapcell.app/v1/gh/torvalds/linux
 <span class="comment"># Or add as remote and fetch/pull later</span>
 <span class="prompt">$</span> git remote add gost https://anon:@gitgost.leapcell.app/v1/gh/torvalds/linux


### PR DESCRIPTION
…-pack handlers

Eliminado uso de GITHUB_TOKEN y headers Authorization en UploadPackDiscoveryHandler y UploadPackHandler. Removida validación de Authorization y respuesta 401 con WWW-Authenticate que forzaba negociación de credenciales. Eliminado comentario sobre prefijo anon: en ejemplo de clone/fetch en index.html.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub API requests no longer enforce authentication validation, removing 401 errors for missing authorization credentials.

* **Chores**
  * Code cleanup and minor refactoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->