### PR TITLE
Add Accept header to upload-pack requests and allow anonymous access …

### DIFF
--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -310,6 +310,7 @@ func UploadPackHandler(c *gin.Context) {
 		return
 	}
 	req.Header.Set("Content-Type", "application/x-git-upload-pack-request")
+	req.Header.Set("Accept", "application/x-git-upload-pack-result")
 	req.Header.Set("User-Agent", "git/2.0")
 
 	resp, err := uploadPackClient.Do(req)

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -62,6 +62,7 @@ func anonymousAuthMiddleware(apiKey string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// Permitir siempre git-receive-pack sin autenticación (anonimato)
 		if strings.Contains(c.Request.URL.Path, "git-receive-pack") ||
+			strings.Contains(c.Request.URL.Path, "git-upload-pack") ||
 			strings.Contains(c.Request.URL.Path, "info/refs") {
 			c.Next()
 			return

--- a/web/index.html
+++ b/web/index.html
@@ -141,11 +141,14 @@
             display: flex;
             align-items: center;
             justify-content: center;
+            vertical-align: middle;
+            line-height: 1;
             box-shadow: 0 2px 8px var(--shadow);
             transition: box-shadow 0.2s ease, transform 0.15s ease;
             padding: 0;
             font-size: 1rem;
             color: var(--fg);
+            margin-top: 14px;
         }
         .theme-btn:hover {
             box-shadow: 0 4px 14px var(--shadow-hover);


### PR DESCRIPTION
…to git-upload-pack endpoint

Agregado header Accept: application/x-git-upload-pack-result en UploadPackHandler para cumplir especificación Git HTTP. Incluido git-upload-pack en middleware de autenticación anónima junto a git-receive-pack e info/refs. Ajustado alineamiento vertical y margen superior de botones de tema en UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Git upload-pack requests are now accessible without requiring authentication, aligning with standard Git protocol endpoint behavior for improved accessibility.

* **Bug Fixes**
  * Enhanced Git protocol request handling with improved HTTP header support for better protocol negotiation during Git operations.

* **Style**
  * Refined theme toggle button styling with improved vertical alignment and spacing for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->