### PR TITLE
chore: remove FUNDING.yml and add exiftool metadata stripping guide

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,0 @@
-# These are supported funding model platforms
-
-github: livrasand
-issuehunt: livrasand

--- a/README.md
+++ b/README.md
@@ -287,6 +287,52 @@ torsocks curl https://check.torproject.org/api/ip
 
 > **Heads-up:** Tor is slow. A push that normally takes seconds may take a few minutes. This is expected — Tor routes traffic through three encrypted nodes worldwide. gitGost's 10 MB commit limit is partly sized with this in mind.
 
+### Strip metadata from binary files before committing
+
+gitGost anonymizes commit metadata, but **binary files (images, PDFs, Office documents) can contain embedded metadata** — EXIF data, GPS coordinates, author names, device info — that reveal your identity regardless of commit anonymization. Strip it before committing with **exiftool**.
+
+#### Install
+
+```bash
+# Debian / Ubuntu
+sudo apt install libimage-exiftool-perl
+
+# Arch
+sudo pacman -S perl-image-exiftool
+
+# macOS
+brew install exiftool
+
+# Windows: download the executable from https://exiftool.org
+# Extract exiftool(-k).exe, rename to exiftool.exe, place in PATH
+```
+
+#### Verify and strip
+
+```bash
+# Check what metadata a file exposes
+exiftool photo.jpg
+# → GPS Latitude  : 48.8566   ← your location
+# → Author        : John Doe  ← your name
+
+# Strip all metadata from a single file
+exiftool -all= photo.jpg
+
+# Strip recursively from a directory
+exiftool -all= -r ./assets/
+```
+
+#### Then commit and push safely
+
+```bash
+git add assets/
+git commit -am "add: project screenshots"
+git push gost my-branch:main
+# → PR opened as @gitgost-anonymous — no metadata, no trace
+```
+
+> **Note:** exiftool creates backup files (`*_original`) by default. Add `-overwrite_original` to skip them: `exiftool -all= -overwrite_original photo.jpg`.
+
 ### Windows alternatives
 
 `torsocks` is not available on Windows natively. Use one of the following options instead.

--- a/web/index.html
+++ b/web/index.html
@@ -991,8 +991,9 @@
             <div class="terminal-tabs">
                 <button class="terminal-tab active" data-terminal="push">Push / PR</button>
                 <button class="terminal-tab" data-terminal="update">Update PR</button>
-                <button class="terminal-tab" data-terminal="fetch">Fetch / Pull (optional)</button>
+                <button class="terminal-tab" data-terminal="fetch">Fetch / Pull</button>
                 <button class="terminal-tab" data-terminal="tor">Push via Tor</button>
+                <button class="terminal-tab" data-terminal="exif">Strip Metadata</button>
             </div>
             <div class="terminal" id="terminal-push"><div class="terminal-titlebar"><span class="terminal-btn close"></span><span class="terminal-btn min"></span><span class="terminal-btn max"></span></div><div class="terminal-body"><span class="comment"># Add as remote → push → done. Fully anonymous.</span>
 <span class="prompt">$</span> git remote add gost https://gitgost.fly.dev/v1/gh/torvalds/linux
@@ -1021,6 +1022,63 @@ The word 'recieve' should be 'receive'."
 <span class="prompt">$</span> git fetch gost
 <span class="prompt">$</span> git pull gost main
 <span class="success">→</span> Repository cloned with zero identity exposure</div>
+            </div>
+
+            <div id="terminal-exif" style="display:none;">
+                <p style="color:var(--fg-secondary);margin:0 0 1rem;max-width:56rem;">gitGost anonymizes commit metadata, but <strong>binary files (images, PDFs, Office documents) can contain embedded metadata</strong> — EXIF data, GPS coordinates, author names — that reveal your identity regardless of commit anonymization. Strip it before committing with <strong>exiftool</strong>.</p>
+                <div class="terminal-tabs">
+                    <button class="terminal-tab active" data-exif="linux">Linux / macOS</button>
+                    <button class="terminal-tab" data-exif="windows">Windows</button>
+                </div>
+                <div class="terminal" id="exif-linux"><div class="terminal-titlebar"><span class="terminal-btn close"></span><span class="terminal-btn min"></span><span class="terminal-btn max"></span></div><div class="terminal-body"><span class="comment"># Install exiftool</span>
+<span class="prompt">$</span> sudo apt install libimage-exiftool-perl  <span class="comment"># Debian / Ubuntu</span>
+<span class="prompt">$</span> sudo pacman -S perl-image-exiftool      <span class="comment"># Arch</span>
+<span class="prompt">$</span> brew install exiftool                  <span class="comment"># macOS</span>
+
+<span class="comment"># Verify a file has metadata before stripping</span>
+<span class="prompt">$</span> exiftool photo.jpg
+<span class="success">→</span> GPS Latitude  : <span class="hl">48.8566</span>  ← your location
+<span class="success">→</span> Author        : <span class="hl">John Doe</span>  ← your name
+
+<span class="comment"># Strip all metadata from a single file</span>
+<span class="prompt">$</span> exiftool -all= photo.jpg
+<span class="success">→</span> 1 image files updated
+
+<span class="comment"># Strip recursively from a directory</span>
+<span class="prompt">$</span> exiftool -all= -r ./assets/
+<span class="success">→</span> 12 image files updated
+
+<span class="comment"># Now commit and push safely</span>
+<span class="prompt">$</span> git add assets/
+<span class="prompt">$</span> git commit -am "add: project screenshots"
+<span class="prompt">$</span> git push gost my-branch:main
+<span class="success">→</span> PR opened as @gitgost-anonymous — no metadata, no trace</div>
+                </div>
+                <div class="terminal" id="exif-windows" style="display:none;"><div class="terminal-titlebar"><span class="terminal-btn close"></span><span class="terminal-btn min"></span><span class="terminal-btn max"></span></div><div class="terminal-body"><span class="comment"># 1. Download exiftool from https://exiftool.org</span>
+<span class="comment">#    Get the Windows Executable (.zip), extract exiftool(-k).exe</span>
+<span class="comment">#    Rename it to exiftool.exe and place it in C:\Windows or your PATH</span>
+
+<span class="comment"># 2. Open Command Prompt or PowerShell</span>
+
+<span class="comment"># Verify metadata exists</span>
+<span class="prompt">&gt;</span> exiftool photo.jpg
+<span class="success">→</span> GPS Latitude  : <span class="hl">48.8566</span>
+<span class="success">→</span> Author        : <span class="hl">John Doe</span>
+
+<span class="comment"># Strip all metadata from a file</span>
+<span class="prompt">&gt;</span> exiftool -all= photo.jpg
+<span class="success">→</span> 1 image files updated
+
+<span class="comment"># Strip recursively from a folder</span>
+<span class="prompt">&gt;</span> exiftool -all= -r .\assets\
+<span class="success">→</span> 12 image files updated
+
+<span class="comment"># Now commit and push safely</span>
+<span class="prompt">&gt;</span> git add assets/
+<span class="prompt">&gt;</span> git commit -am "add: project screenshots"
+<span class="prompt">&gt;</span> git push gost my-branch:main
+<span class="success">→</span> PR opened as @gitgost-anonymous — no metadata, no trace</div>
+                </div>
             </div>
 
             <div id="terminal-tor" style="display:none;">
@@ -1868,6 +1926,18 @@ The word 'recieve' should be 'receive'."
                 document.getElementById('terminal-update').style.display = target === 'update' ? '' : 'none';
                 document.getElementById('terminal-fetch').style.display = target === 'fetch' ? '' : 'none';
                 document.getElementById('terminal-tor').style.display = target === 'tor' ? '' : 'none';
+                document.getElementById('terminal-exif').style.display = target === 'exif' ? '' : 'none';
+            });
+        });
+
+        // Exif sub-tab switching
+        document.querySelectorAll('[data-exif]').forEach(tab => {
+            tab.addEventListener('click', () => {
+                document.querySelectorAll('[data-exif]').forEach(t => t.classList.remove('active'));
+                tab.classList.add('active');
+                const target = tab.dataset.exif;
+                document.getElementById('exif-linux').style.display = target === 'linux' ? '' : 'none';
+                document.getElementById('exif-windows').style.display = target === 'windows' ? '' : 'none';
             });
         });
 


### PR DESCRIPTION
Eliminado .github/FUNDING.yml. Agregada sección "Strip metadata from binary files before committing" en README con instalación de exiftool (Debian/Ubuntu/Arch/macOS/Windows), comandos de verificación y stripping recursivo. Agregada pestaña "Strip Metadata" en web/index.html con sub-tabs Linux/macOS y Windows, ejemplos de terminal con detección de GPS/Author y flujo completo de limpieza antes de commit/push anónimo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on stripping metadata from binary files, including installation and usage instructions.

* **New Features**
  * Added metadata stripping workflow interface with platform-specific instructions and terminal examples.

* **Chores**
  * Removed funding configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->