### PR TITLE
feat: add GitLab provider support with unified multi-platform architcture

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@
 # Get one from: https://github.com/settings/tokens
 GITHUB_TOKEN=your_github_token_here
 
+# Optional: GitLab personal access token with api scope (for GitLab support)
+# Get one from: https://gitlab.com/-/user_settings/personal_access_tokens
+GITLAB_TOKEN=
+
 # Optional: API key for authentication (if not set, no auth required)
 GITGOST_API_KEY=gitgost-anonymous
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ type Config struct {
 	WriteTimeout   time.Duration
 	APIKey         string
 	GitHubToken    string
+	GitLabToken    string
 	LogFormat      string
 	SupabaseURL    string
 	SupabaseKey    string
@@ -26,7 +27,8 @@ func Load() *Config {
 		WriteTimeout:   getDurationEnv("WRITE_TIMEOUT", 30*time.Second),
 		APIKey:         getEnv("GITGOST_API_KEY", ""),
 		GitHubToken:    getEnv("GITHUB_TOKEN", ""),
-		LogFormat:      getEnv("LOG_FORMAT", "text"), 
+		GitLabToken:    getEnv("GITLAB_TOKEN", ""),
+		LogFormat:      getEnv("LOG_FORMAT", "text"),
 		SupabaseURL:    getEnv("SUPABASE_URL", ""),
 		SupabaseKey:    getEnv("SUPABASE_KEY", ""),
 		PanicPassword:  getEnv("PANIC_PASSWORD", ""),

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -11,7 +11,7 @@ func TestPushToGitHub_NoToken(t *testing.T) {
 
 	os.Unsetenv("GITHUB_TOKEN")
 
-	_, err := PushToGitHub("owner", "repo", "/tmp/nonexistent", "forkowner", "")
+	_, err := PushToGitHub("owner", "repo", "/tmp/nonexistent", "forkowner", "", "", "")
 	if err == nil {
 		t.Error("Expected error when GITHUB_TOKEN is not set")
 	}
@@ -31,7 +31,7 @@ func TestReceivePack(t *testing.T) {
 	}()
 
 	os.Unsetenv("GITHUB_TOKEN")
-	_, _, _, err := ReceivePack(tempDir, []byte{}, "owner", "repo")
+	_, _, _, err := ReceivePack(tempDir, []byte{}, "owner", "repo", "", "")
 	if err == nil {
 		t.Error("Expected error when GITHUB_TOKEN is not set")
 	}

--- a/internal/git/push.go
+++ b/internal/git/push.go
@@ -17,10 +17,16 @@ func min(a, b int) int {
 	return b
 }
 
-func PushToGitHub(owner, repo, tempDir, forkOwner, targetBranch string) (string, error) {
-	token := os.Getenv("GITHUB_TOKEN")
+// PushToGitHub pushes to a fork repository.
+// pushURL is the full HTTPS URL of the fork; if empty, defaults to GitHub.
+// tokenEnvVar is the env var name for the auth token; if empty, defaults to GITHUB_TOKEN.
+func PushToGitHub(owner, repo, tempDir, forkOwner, targetBranch string, pushURL string, tokenEnvVar string) (string, error) {
+	if tokenEnvVar == "" {
+		tokenEnvVar = "GITHUB_TOKEN"
+	}
+	token := os.Getenv(tokenEnvVar)
 	if token == "" {
-		return "", fmt.Errorf("GITHUB_TOKEN not set")
+		return "", fmt.Errorf("%s not set", tokenEnvVar)
 	}
 
 	branch := targetBranch
@@ -34,7 +40,10 @@ func PushToGitHub(owner, repo, tempDir, forkOwner, targetBranch string) (string,
 		return "", err
 	}
 
-	forkURL := fmt.Sprintf("https://github.com/%s/%s.git", forkOwner, repo)
+	forkURL := pushURL
+	if forkURL == "" {
+		forkURL = fmt.Sprintf("https://github.com/%s/%s.git", forkOwner, repo)
+	}
 	fmt.Printf("DEBUG: Pushing to fork: %s\n", forkURL)
 	fmt.Printf("DEBUG: Branch name: %s\n", branch)
 
@@ -60,8 +69,8 @@ func PushToGitHub(owner, repo, tempDir, forkOwner, targetBranch string) (string,
 		RemoteName: "fork",
 		RefSpecs:   []config.RefSpec{refSpec},
 		Auth: &http.BasicAuth{
-			Username: "x-access-token", 
-			Password: token,            
+			Username: "x-access-token",
+			Password: token,
 		},
 		Force: targetBranch != "",
 	})

--- a/internal/git/receive.go
+++ b/internal/git/receive.go
@@ -25,7 +25,7 @@ func ParsePktLine(r io.Reader) ([]byte, error) {
 
 	lenStr := string(lenBuf)
 	if lenStr == "0000" {
-		return nil, nil 
+		return nil, nil
 	}
 
 	length, err := strconv.ParseInt(lenStr, 16, 32)
@@ -136,15 +136,22 @@ func ExtractPackfile(body []byte) ([]byte, *RefUpdate, string, error) {
 	return packfile, refUpdate, prHash, nil
 }
 
-// ReceivePack clona el repo de GitHub y aplica el packfile recibido, retorna el SHA del nuevo commit, el mensaje del commit y el pr-hash push-option (si fue enviado).
-func ReceivePack(tempDir string, body []byte, owner string, repo string) (string, string, string, error) {
-	// Clonar el repo de GitHub para tener los objetos base
-	token := os.Getenv("GITHUB_TOKEN")
+// ReceivePack clona el repo remoto y aplica el packfile recibido, retorna el SHA del nuevo commit, el mensaje del commit y el pr-hash push-option (si fue enviado).
+// cloneURL es la URL HTTPS completa del repositorio; si está vacía se usa GitHub por defecto (compatibilidad).
+// tokenEnvVar es el nombre de la variable de entorno con el token de autenticación; si está vacío usa GITHUB_TOKEN.
+func ReceivePack(tempDir string, body []byte, owner string, repo string, cloneURL string, tokenEnvVar string) (string, string, string, error) {
+	if cloneURL == "" {
+		cloneURL = fmt.Sprintf("https://github.com/%s/%s.git", owner, repo)
+	}
+	if tokenEnvVar == "" {
+		tokenEnvVar = "GITHUB_TOKEN"
+	}
+	token := os.Getenv(tokenEnvVar)
 	if token == "" {
-		return "", "", "", fmt.Errorf("GITHUB_TOKEN not set")
+		return "", "", "", fmt.Errorf("%s not set", tokenEnvVar)
 	}
 
-	repoURL := fmt.Sprintf("https://github.com/%s/%s.git", owner, repo)
+	repoURL := cloneURL
 	fmt.Printf("DEBUG: Cloning %s/%s...\n", owner, repo)
 
 	_, err := git.PlainClone(tempDir, false, &git.CloneOptions{

--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -23,12 +23,24 @@ import (
 	"github.com/livrasand/gitGost/internal/database"
 	"github.com/livrasand/gitGost/internal/git"
 	"github.com/livrasand/gitGost/internal/github"
+	"github.com/livrasand/gitGost/internal/provider"
+	ghprovider "github.com/livrasand/gitGost/internal/provider/github"
+	glprovider "github.com/livrasand/gitGost/internal/provider/gitlab"
 	"github.com/livrasand/gitGost/internal/utils"
 
 	"github.com/gin-gonic/gin"
 )
 
 var uploadPackClient = &http.Client{Timeout: 30 * time.Second}
+
+// providerFromPath returns the appropriate Provider based on the URL path prefix.
+// /v1/gh/... → GitHub (default), /v1/gl/... → GitLab.
+func providerFromPath(path string) provider.Provider {
+	if strings.HasPrefix(path, "/v1/gl/") {
+		return glprovider.New()
+	}
+	return ghprovider.New()
+}
 
 const anonymousFriendlyBadgeSVG = `<svg xmlns="http://www.w3.org/2000/svg" width="180" height="20" viewBox="0 0 180 20">
   <rect width="180" height="20" fill="#4CAF50" rx="3"/>
@@ -80,8 +92,8 @@ func ReceivePackDiscoveryHandler(c *gin.Context) {
 	owner := c.Param("owner")
 	repo := c.Param("repo")
 
-	// Get refs from GitHub
-	refs, err := github.GetRefs(owner, repo)
+	prov := providerFromPath(c.Request.URL.Path)
+	refs, err := prov.GetRefs(owner, repo)
 	if err != nil {
 		utils.Log("Error getting refs: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get refs"})
@@ -103,7 +115,7 @@ func ReceivePackDiscoveryHandler(c *gin.Context) {
 	first := true
 	for _, ref := range refs {
 		if strings.HasPrefix(ref.Ref, "refs/heads/") || strings.HasPrefix(ref.Ref, "refs/tags/") {
-			line := fmt.Sprintf("%s %s", ref.GetSha(), ref.Ref)
+			line := fmt.Sprintf("%s %s", ref.SHA, ref.Ref)
 			if first {
 				line += "\x00" + capabilities
 				first = false
@@ -175,8 +187,11 @@ func ReceivePackHandler(c *gin.Context) {
 	// Record push globally to detect botnet/script patterns across IPs
 	go recordGlobalBurst(ip)
 
+	// Detect provider from request path
+	prov := providerFromPath(c.Request.URL.Path)
+
 	// Check repository opt-out policy (.gitgost.yml DENY_ALL)
-	policy, err := github.GetRepoPolicy(owner, repo)
+	policy, err := prov.GetRepoPolicy(owner, repo)
 	if err == nil && policy != nil && policy.DenyAll {
 		c.Writer.Header().Set("Content-Type", "application/x-git-receive-pack-result")
 		c.Writer.WriteHeader(http.StatusOK)
@@ -227,7 +242,7 @@ func ReceivePackHandler(c *gin.Context) {
 	WriteSidebandLine(&response, 2, "remote: gitGost: Processing your anonymous contribution...")
 
 	// Process the packfile
-	newSHA, commitMessage, receivedPRHash, err := git.ReceivePack(tempDir, body, owner, repo)
+	newSHA, commitMessage, receivedPRHash, err := git.ReceivePack(tempDir, body, owner, repo, prov.CloneURL(owner, repo), prov.TokenEnvVar())
 	if err != nil {
 		utils.Log("Error receiving pack: %v", err)
 		WriteSidebandLine(&response, 3, fmt.Sprintf("unpack error: %v", err))
@@ -241,7 +256,7 @@ func ReceivePackHandler(c *gin.Context) {
 
 	// Create a fork of the repository
 	WriteSidebandLine(&response, 2, "remote: gitGost: Creating fork...")
-	forkOwner, err := github.ForkRepo(owner, repo)
+	forkOwner, err := prov.ForkRepo(owner, repo)
 	if err != nil {
 		utils.Log("Error creating fork: %v", err)
 		WriteSidebandLine(&response, 1, "unpack ok\n")
@@ -262,7 +277,7 @@ func ReceivePackHandler(c *gin.Context) {
 		branchFromHash := fmt.Sprintf("gitgost-%s", receivedPRHash)
 		WriteSidebandLine(&response, 2, fmt.Sprintf("remote: gitGost: Updating existing PR (hash: %s)...", receivedPRHash))
 
-		existingPRURL, branchExists, err := github.GetExistingPR(owner, repo, forkOwner, branchFromHash)
+		existingPRURL, branchExists, err := prov.GetExistingMR(owner, repo, forkOwner, branchFromHash)
 		if err != nil {
 			utils.Log("Error checking existing PR: %v", err)
 		}
@@ -270,7 +285,7 @@ func ReceivePackHandler(c *gin.Context) {
 		if branchExists {
 			// Push to the fork in the existing branch (force)
 			WriteSidebandLine(&response, 2, "remote: gitGost: Pushing update to existing branch...")
-			branch, err = git.PushToGitHub(owner, repo, tempDir, forkOwner, branchFromHash)
+			branch, err = git.PushToGitHub(owner, repo, tempDir, forkOwner, branchFromHash, prov.PushURL(forkOwner, repo), prov.TokenEnvVar())
 			if err != nil {
 				utils.Log("Error pushing update to fork: %v", err)
 				WriteSidebandLine(&response, 1, "unpack ok\n")
@@ -287,7 +302,7 @@ func ReceivePackHandler(c *gin.Context) {
 			} else {
 				// Branch exists but PR was closed/merged: create new PR
 				WriteSidebandLine(&response, 2, "remote: gitGost: PR was closed, creating new PR on existing branch...")
-				prURL, err = github.CreatePR(owner, repo, branch, forkOwner, commitMessage)
+				prURL, err = prov.CreateMR(owner, repo, branch, forkOwner, commitMessage)
 				if err != nil {
 					utils.Log("Error creating PR on existing branch: %v", err)
 					WriteSidebandLine(&response, 1, "unpack ok\n")
@@ -312,7 +327,7 @@ func ReceivePackHandler(c *gin.Context) {
 	if !isUpdate {
 		// Normal flow: push to new branch and create PR
 		WriteSidebandLine(&response, 2, "remote: gitGost: Pushing to fork...")
-		branch, err = git.PushToGitHub(owner, repo, tempDir, forkOwner, "")
+		branch, err = git.PushToGitHub(owner, repo, tempDir, forkOwner, "", prov.PushURL(forkOwner, repo), prov.TokenEnvVar())
 		if err != nil {
 			utils.Log("Error pushing to fork: %v", err)
 			WriteSidebandLine(&response, 1, "unpack ok\n")
@@ -327,7 +342,7 @@ func ReceivePackHandler(c *gin.Context) {
 
 		// Create PR from the fork to the original repository
 		WriteSidebandLine(&response, 2, "remote: gitGost: Creating pull request...")
-		prURL, err = github.CreatePR(owner, repo, branch, forkOwner, commitMessage)
+		prURL, err = prov.CreateMR(owner, repo, branch, forkOwner, commitMessage)
 		if err != nil {
 			utils.Log("Error creating PR: %v", err)
 			WriteSidebandLine(&response, 1, "unpack ok\n")
@@ -428,8 +443,9 @@ func UploadPackDiscoveryHandler(c *gin.Context) {
 	owner := c.Param("owner")
 	repo := c.Param("repo")
 
-	githubURL := fmt.Sprintf("https://github.com/%s/%s.git/info/refs?service=git-upload-pack", owner, repo)
-	req, err := http.NewRequest("GET", githubURL, nil)
+	prov := providerFromPath(c.Request.URL.Path)
+	remoteURL := prov.CloneURL(owner, repo) + "/info/refs?service=git-upload-pack"
+	req, err := http.NewRequest("GET", remoteURL, nil)
 	if err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to build request"})
 		return
@@ -439,7 +455,7 @@ func UploadPackDiscoveryHandler(c *gin.Context) {
 	resp, err := uploadPackClient.Do(req)
 	if err != nil {
 		utils.Log("UploadPackDiscovery error: %v", err)
-		c.AbortWithStatusJSON(http.StatusBadGateway, gin.H{"error": "failed to reach GitHub"})
+		c.AbortWithStatusJSON(http.StatusBadGateway, gin.H{"error": "failed to reach remote"})
 		return
 	}
 	defer resp.Body.Close()
@@ -468,8 +484,9 @@ func UploadPackHandler(c *gin.Context) {
 		return
 	}
 
-	githubURL := fmt.Sprintf("https://github.com/%s/%s.git/git-upload-pack", owner, repo)
-	req, err := http.NewRequest("POST", githubURL, bytes.NewReader(body))
+	prov := providerFromPath(c.Request.URL.Path)
+	remoteURL := prov.CloneURL(owner, repo) + "/git-upload-pack"
+	req, err := http.NewRequest("POST", remoteURL, bytes.NewReader(body))
 	if err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to build request"})
 		return
@@ -903,7 +920,13 @@ func RollbackBurstHandler(c *gin.Context) {
 			defer wg.Done()
 			closeConcurrency <- struct{}{}
 			defer func() { <-closeConcurrency }()
-			if err := github.ClosePRByURL(u); err != nil {
+			var closeErr error
+			if strings.Contains(u, "gitlab.com") {
+				closeErr = glprovider.New().CloseMRByURL(u)
+			} else {
+				closeErr = github.ClosePRByURL(u)
+			}
+			if err := closeErr; err != nil {
 				utils.Log("rollback: failed to close %s: %v", u, err)
 				mu.Lock()
 				failed = append(failed, u)
@@ -1024,7 +1047,8 @@ func CreateAnonymousIssueHandler(c *gin.Context) {
 		return
 	}
 
-	issueURL, issueNumber, err := github.CreateAnonymousIssue(owner, repo, req.Title, req.Body, req.Labels)
+	prov := providerFromPath(c.Request.URL.Path)
+	issueURL, issueNumber, err := prov.CreateAnonymousIssue(owner, repo, req.Title, req.Body, req.Labels)
 	if err != nil {
 		utils.Log("Error creating issue: %v", err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -1103,7 +1127,8 @@ func CreateAnonymousCommentHandler(c *gin.Context) {
 	legend := fmt.Sprintf("\n\n---\ngoster-%s · karma (%d) · [report](%s)", hash, karma, reportURL)
 	bodyWithLegend := req.Body + legend
 
-	commentURL, err := github.CreateAnonymousComment(owner, repo, number, bodyWithLegend)
+	prov := providerFromPath(c.Request.URL.Path)
+	commentURL, err := prov.CreateAnonymousComment(owner, repo, number, bodyWithLegend)
 	if err != nil {
 		utils.Log("Error creating comment: %v", err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -1181,7 +1206,8 @@ func CreateAnonymousPRCommentHandler(c *gin.Context) {
 	legend := fmt.Sprintf("\n\n---\ngoster-%s · karma (%d) · [report](%s)", hash, karma, reportURL)
 	bodyWithLegend := req.Body + legend
 
-	commentURL, err := github.CreateAnonymousPRComment(owner, repo, number, bodyWithLegend)
+	prov := providerFromPath(c.Request.URL.Path)
+	commentURL, err := prov.CreateAnonymousPRComment(owner, repo, number, bodyWithLegend)
 	if err != nil {
 		utils.Log("Error creating PR comment: %v", err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -1523,7 +1549,11 @@ func serveAnonymousFriendlyBadge(c *gin.Context) {
 		parts := strings.Split(repo, "/")
 		if len(parts) == 2 {
 			owner, repoName := parts[0], parts[1]
-			verified = github.IsRepoVerified(owner, repoName)
+			if c.Query("provider") == "gl" {
+				verified = glprovider.New().IsRepoVerified(owner, repoName)
+			} else {
+				verified = github.IsRepoVerified(owner, repoName)
+			}
 		}
 	}
 

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -162,19 +162,21 @@ func SetupRouter(cfg *config.Config) *gin.Engine {
 	v1.Use(validationMiddleware())
 	v1.Use(anonymousAuthMiddleware(cfg.APIKey))
 	{
+		refsHandler := func(c *gin.Context) {
+			service := c.Query("service")
+			if service == "git-receive-pack" {
+				ReceivePackDiscoveryHandler(c)
+			} else if service == "git-upload-pack" {
+				UploadPackDiscoveryHandler(c)
+			} else {
+				c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Unsupported service"})
+			}
+		}
+
 		gh := v1.Group("/gh")
 		{
 			// Git Smart HTTP - info/refs (discovery)
-			gh.GET("/:owner/:repo/info/refs", func(c *gin.Context) {
-				service := c.Query("service")
-				if service == "git-receive-pack" {
-					ReceivePackDiscoveryHandler(c)
-				} else if service == "git-upload-pack" {
-					UploadPackDiscoveryHandler(c)
-				} else {
-					c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "Unsupported service"})
-				}
-			})
+			gh.GET("/:owner/:repo/info/refs", refsHandler)
 
 			// Git Smart HTTP - receive-pack (push)
 			gh.POST("/:owner/:repo/git-receive-pack", ReceivePackHandler)
@@ -188,6 +190,17 @@ func SetupRouter(cfg *config.Config) *gin.Engine {
 
 			// Comentarios anónimos en Pull Requests
 			gh.POST("/:owner/:repo/pulls/:number/comments/anonymous", CreateAnonymousPRCommentHandler)
+		}
+
+		// GitLab provider — same routes under /gl/
+		gl := v1.Group("/gl")
+		{
+			gl.GET("/:owner/:repo/info/refs", refsHandler)
+			gl.POST("/:owner/:repo/git-receive-pack", ReceivePackHandler)
+			gl.POST("/:owner/:repo/git-upload-pack", UploadPackHandler)
+			gl.POST("/:owner/:repo/issues/anonymous", CreateAnonymousIssueHandler)
+			gl.POST("/:owner/:repo/issues/:number/comments/anonymous", CreateAnonymousCommentHandler)
+			gl.POST("/:owner/:repo/pulls/:number/comments/anonymous", CreateAnonymousPRCommentHandler)
 		}
 	}
 

--- a/internal/provider/github/github.go
+++ b/internal/provider/github/github.go
@@ -1,0 +1,85 @@
+package github
+
+import (
+	"github.com/livrasand/gitGost/internal/github"
+	"github.com/livrasand/gitGost/internal/provider"
+)
+
+// GitHubProvider implements provider.Provider using the existing github package.
+// All real logic lives in internal/github/pr.go — this is a thin adapter.
+type GitHubProvider struct{}
+
+func New() *GitHubProvider {
+	return &GitHubProvider{}
+}
+
+func (p *GitHubProvider) ForkRepo(owner, repo string) (string, error) {
+	return github.ForkRepo(owner, repo)
+}
+
+func (p *GitHubProvider) CreateMR(owner, repo, branch, forkOwner, commitMessage string) (string, error) {
+	return github.CreatePR(owner, repo, branch, forkOwner, commitMessage)
+}
+
+func (p *GitHubProvider) GetRefs(owner, repo string) ([]provider.Ref, error) {
+	ghRefs, err := github.GetRefs(owner, repo)
+	if err != nil {
+		return nil, err
+	}
+	refs := make([]provider.Ref, len(ghRefs))
+	for i, r := range ghRefs {
+		refs[i] = provider.Ref{Ref: r.Ref, SHA: r.GetSha()}
+	}
+	return refs, nil
+}
+
+func (p *GitHubProvider) GetExistingMR(owner, repo, forkOwner, branchName string) (string, bool, error) {
+	return github.GetExistingPR(owner, repo, forkOwner, branchName)
+}
+
+func (p *GitHubProvider) CloseMRByURL(mrURL string) error {
+	return github.ClosePRByURL(mrURL)
+}
+
+func (p *GitHubProvider) GetRepoPolicy(owner, repo string) (*provider.RepoPolicy, error) {
+	ghPolicy, err := github.GetRepoPolicy(owner, repo)
+	if err != nil {
+		return nil, err
+	}
+	if ghPolicy == nil {
+		return &provider.RepoPolicy{}, nil
+	}
+	return &provider.RepoPolicy{DenyAll: ghPolicy.DenyAll}, nil
+}
+
+func (p *GitHubProvider) IsRepoVerified(owner, repo string) bool {
+	return github.IsRepoVerified(owner, repo)
+}
+
+func (p *GitHubProvider) CloneURL(owner, repo string) string {
+	return "https://github.com/" + owner + "/" + repo + ".git"
+}
+
+func (p *GitHubProvider) PushURL(forkOwner, repo string) string {
+	return "https://github.com/" + forkOwner + "/" + repo + ".git"
+}
+
+func (p *GitHubProvider) TokenEnvVar() string {
+	return "GITHUB_TOKEN"
+}
+
+func (p *GitHubProvider) Name() string {
+	return "GitHub"
+}
+
+func (p *GitHubProvider) CreateAnonymousIssue(owner, repo, title, body string, labels []string) (string, int, error) {
+	return github.CreateAnonymousIssue(owner, repo, title, body, labels)
+}
+
+func (p *GitHubProvider) CreateAnonymousComment(owner, repo string, number int, body string) (string, error) {
+	return github.CreateAnonymousComment(owner, repo, number, body)
+}
+
+func (p *GitHubProvider) CreateAnonymousPRComment(owner, repo string, number int, body string) (string, error) {
+	return github.CreateAnonymousPRComment(owner, repo, number, body)
+}

--- a/internal/provider/gitlab/gitlab.go
+++ b/internal/provider/gitlab/gitlab.go
@@ -1,0 +1,503 @@
+package gitlab
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/livrasand/gitGost/internal/provider"
+)
+
+var httpClient = &http.Client{Timeout: 60 * time.Second}
+
+// GitLabProvider implements provider.Provider for GitLab.
+type GitLabProvider struct{}
+
+func New() *GitLabProvider {
+	return &GitLabProvider{}
+}
+
+func (p *GitLabProvider) Name() string {
+	return "GitLab"
+}
+
+func (p *GitLabProvider) TokenEnvVar() string {
+	return "GITLAB_TOKEN"
+}
+
+func (p *GitLabProvider) CloneURL(owner, repo string) string {
+	return "https://gitlab.com/" + owner + "/" + repo + ".git"
+}
+
+func (p *GitLabProvider) PushURL(forkOwner, repo string) string {
+	return "https://gitlab.com/" + forkOwner + "/" + repo + ".git"
+}
+
+// projectID returns the URL-encoded "namespace/project" identifier used by GitLab API.
+func projectID(owner, repo string) string {
+	return url.PathEscape(owner + "/" + repo)
+}
+
+func token() string {
+	return os.Getenv("GITLAB_TOKEN")
+}
+
+func authHeader(req *http.Request) {
+	t := token()
+	if t != "" {
+		req.Header.Set("PRIVATE-TOKEN", t)
+	}
+}
+
+// ForkRepo forks owner/repo into the authenticated user's namespace.
+// Returns the fork owner (username of the token holder).
+func (p *GitLabProvider) ForkRepo(owner, repo string) (string, error) {
+	t := token()
+	if t == "" {
+		return "", fmt.Errorf("GITLAB_TOKEN not set")
+	}
+
+	// Get current user login
+	userReq, err := http.NewRequest("GET", "https://gitlab.com/api/v4/user", nil)
+	if err != nil {
+		return "", err
+	}
+	authHeader(userReq)
+	userResp, err := httpClient.Do(userReq)
+	if err != nil {
+		return "", err
+	}
+	defer userResp.Body.Close()
+
+	var user struct {
+		Username string `json:"username"`
+	}
+	if err := json.NewDecoder(userResp.Body).Decode(&user); err != nil {
+		return "", err
+	}
+	if user.Username == "" {
+		return "", fmt.Errorf("could not get GitLab username")
+	}
+
+	forkOwner := user.Username
+
+	// Check if fork already exists
+	checkURL := fmt.Sprintf("https://gitlab.com/api/v4/projects/%s", projectID(forkOwner, repo))
+	checkReq, err := http.NewRequest("GET", checkURL, nil)
+	if err != nil {
+		return "", err
+	}
+	authHeader(checkReq)
+	checkResp, err := httpClient.Do(checkReq)
+	if err != nil {
+		return "", err
+	}
+	checkResp.Body.Close()
+	if checkResp.StatusCode == http.StatusOK {
+		return forkOwner, nil
+	}
+
+	// Create fork
+	forkURL := fmt.Sprintf("https://gitlab.com/api/v4/projects/%s/fork", projectID(owner, repo))
+	forkReq, err := http.NewRequest("POST", forkURL, nil)
+	if err != nil {
+		return "", err
+	}
+	authHeader(forkReq)
+	forkReq.Header.Set("Content-Type", "application/json")
+
+	forkResp, err := httpClient.Do(forkReq)
+	if err != nil {
+		return "", err
+	}
+	defer forkResp.Body.Close()
+
+	if forkResp.StatusCode != http.StatusCreated && forkResp.StatusCode != http.StatusAccepted {
+		return "", fmt.Errorf("failed to fork GitLab project: %s", forkResp.Status)
+	}
+
+	return forkOwner, nil
+}
+
+// CreateMR creates a Merge Request from forkOwner:branch → owner/repo:main.
+func (p *GitLabProvider) CreateMR(owner, repo, branch, forkOwner, commitMessage string) (string, error) {
+	t := token()
+	if t == "" {
+		return "", fmt.Errorf("GITLAB_TOKEN not set")
+	}
+
+	apiURL := fmt.Sprintf("https://gitlab.com/api/v4/projects/%s/merge_requests", projectID(owner, repo))
+
+	mrBody := fmt.Sprintf("%s\n\n---\n\n*This is an anonymous contribution made via [gitGost](https://gitgost.fly.dev).*\n\n*The original author's identity has been anonymized to protect their privacy.*", commitMessage)
+
+	payload := map[string]interface{}{
+		"source_branch":       branch,
+		"target_branch":       "main",
+		"title":               "Anonymous contribution via gitGost",
+		"description":         mrBody,
+		"source_project_id":   fmt.Sprintf("%s/%s", forkOwner, repo),
+		"allow_collaboration": true,
+	}
+
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequest("POST", apiURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return "", err
+	}
+	authHeader(req)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		var errResp map[string]interface{}
+		json.NewDecoder(resp.Body).Decode(&errResp)
+		return "", fmt.Errorf("failed to create GitLab MR: %s", resp.Status)
+	}
+
+	var result struct {
+		WebURL string `json:"web_url"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+
+	return result.WebURL, nil
+}
+
+// GetRefs returns all branches for the given GitLab project.
+// Works without a token for public repos.
+func (p *GitLabProvider) GetRefs(owner, repo string) ([]provider.Ref, error) {
+	apiURL := fmt.Sprintf("https://gitlab.com/api/v4/projects/%s/repository/branches", projectID(owner, repo))
+	req, err := http.NewRequest("GET", apiURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	authHeader(req)
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get GitLab refs: %s", resp.Status)
+	}
+
+	var branches []struct {
+		Name   string `json:"name"`
+		Commit struct {
+			ID string `json:"id"`
+		} `json:"commit"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&branches); err != nil {
+		return nil, err
+	}
+
+	refs := make([]provider.Ref, len(branches))
+	for i, b := range branches {
+		refs[i] = provider.Ref{
+			Ref: "refs/heads/" + b.Name,
+			SHA: b.Commit.ID,
+		}
+	}
+	return refs, nil
+}
+
+// GetExistingMR checks if an open MR exists from forkOwner:branchName.
+func (p *GitLabProvider) GetExistingMR(owner, repo, forkOwner, branchName string) (string, bool, error) {
+	t := token()
+	if t == "" {
+		return "", false, fmt.Errorf("GITLAB_TOKEN not set")
+	}
+
+	// Check if branch exists in fork
+	branchURL := fmt.Sprintf("https://gitlab.com/api/v4/projects/%s/repository/branches/%s",
+		projectID(forkOwner, repo), url.PathEscape(branchName))
+	branchReq, err := http.NewRequest("GET", branchURL, nil)
+	if err != nil {
+		return "", false, err
+	}
+	authHeader(branchReq)
+
+	branchResp, err := httpClient.Do(branchReq)
+	if err != nil {
+		return "", false, err
+	}
+	branchResp.Body.Close()
+
+	if branchResp.StatusCode != http.StatusOK {
+		return "", false, nil
+	}
+
+	// Branch exists; search for open MR
+	mrListURL := fmt.Sprintf(
+		"https://gitlab.com/api/v4/projects/%s/merge_requests?state=opened&source_branch=%s&per_page=1",
+		projectID(owner, repo), url.QueryEscape(branchName),
+	)
+	mrReq, err := http.NewRequest("GET", mrListURL, nil)
+	if err != nil {
+		return "", true, err
+	}
+	authHeader(mrReq)
+
+	mrResp, err := httpClient.Do(mrReq)
+	if err != nil {
+		return "", true, err
+	}
+	defer mrResp.Body.Close()
+
+	if mrResp.StatusCode != http.StatusOK {
+		return "", true, fmt.Errorf("failed to list GitLab MRs: %s", mrResp.Status)
+	}
+
+	var mrs []struct {
+		WebURL string `json:"web_url"`
+	}
+	if err := json.NewDecoder(mrResp.Body).Decode(&mrs); err != nil {
+		return "", true, err
+	}
+
+	if len(mrs) == 0 {
+		return "", true, nil
+	}
+	return mrs[0].WebURL, true, nil
+}
+
+// CloseMRByURL closes a GitLab MR given its web URL.
+// Expected format: https://gitlab.com/{owner}/{repo}/-/merge_requests/{iid}
+func (p *GitLabProvider) CloseMRByURL(mrURL string) error {
+	t := token()
+	if t == "" {
+		return fmt.Errorf("GITLAB_TOKEN not set")
+	}
+
+	// Parse: https://gitlab.com/<owner>/<repo>/-/merge_requests/<iid>
+	trimmed := strings.TrimPrefix(mrURL, "https://gitlab.com/")
+	parts := strings.Split(trimmed, "/-/merge_requests/")
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid GitLab MR URL: %s", mrURL)
+	}
+	projectPath := parts[0]
+	iid := parts[1]
+
+	apiURL := fmt.Sprintf("https://gitlab.com/api/v4/projects/%s/merge_requests/%s",
+		url.PathEscape(projectPath), iid)
+
+	payload, err := json.Marshal(map[string]string{"state_event": "close"})
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("PUT", apiURL, bytes.NewBuffer(payload))
+	if err != nil {
+		return err
+	}
+	authHeader(req)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to close GitLab MR %s: status %s", mrURL, resp.Status)
+	}
+	return nil
+}
+
+// GetRepoPolicy reads .gitgost.yml from a GitLab repository.
+func (p *GitLabProvider) GetRepoPolicy(owner, repo string) (*provider.RepoPolicy, error) {
+	t := token()
+	apiURL := fmt.Sprintf("https://gitlab.com/api/v4/projects/%s/repository/files/.gitgost.yml/raw",
+		projectID(owner, repo))
+
+	req, err := http.NewRequest("GET", apiURL, nil)
+	if err != nil {
+		return &provider.RepoPolicy{}, nil
+	}
+	if t != "" {
+		authHeader(req)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return &provider.RepoPolicy{}, nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return &provider.RepoPolicy{}, nil
+	}
+
+	// Parse DENY_ALL from raw YAML content
+	var buf bytes.Buffer
+	buf.ReadFrom(resp.Body)
+	content := buf.String()
+
+	// Simple check: avoid importing yaml just for one field
+	if strings.Contains(content, "DENY_ALL: true") {
+		return &provider.RepoPolicy{DenyAll: true}, nil
+	}
+	return &provider.RepoPolicy{}, nil
+}
+
+// CreateAnonymousIssue creates an issue on a GitLab project.
+func (p *GitLabProvider) CreateAnonymousIssue(owner, repo, title, body string, labels []string) (string, int, error) {
+	t := token()
+	if t == "" {
+		return "", 0, fmt.Errorf("GITLAB_TOKEN not set")
+	}
+
+	apiURL := fmt.Sprintf("https://gitlab.com/api/v4/projects/%s/issues", projectID(owner, repo))
+
+	payload := map[string]interface{}{
+		"title":       title,
+		"description": body,
+	}
+	if len(labels) > 0 {
+		payload["labels"] = strings.Join(labels, ",")
+	}
+
+	jsonData, err := json.Marshal(payload)
+	if err != nil {
+		return "", 0, err
+	}
+
+	req, err := http.NewRequest("POST", apiURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return "", 0, err
+	}
+	authHeader(req)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusForbidden {
+		return "", 0, fmt.Errorf("issues are disabled or not accessible in this GitLab repository")
+	}
+	if resp.StatusCode != http.StatusCreated {
+		return "", 0, fmt.Errorf("failed to create GitLab issue: %s", resp.Status)
+	}
+
+	var result struct {
+		IID    int    `json:"iid"`
+		WebURL string `json:"web_url"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", 0, err
+	}
+	return result.WebURL, result.IID, nil
+}
+
+// CreateAnonymousComment posts a note (comment) on a GitLab issue.
+func (p *GitLabProvider) CreateAnonymousComment(owner, repo string, number int, body string) (string, error) {
+	t := token()
+	if t == "" {
+		return "", fmt.Errorf("GITLAB_TOKEN not set")
+	}
+
+	apiURL := fmt.Sprintf("https://gitlab.com/api/v4/projects/%s/issues/%d/notes", projectID(owner, repo), number)
+
+	jsonData, err := json.Marshal(map[string]string{"body": body})
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequest("POST", apiURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return "", err
+	}
+	authHeader(req)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("failed to create GitLab issue note: %s", resp.Status)
+	}
+
+	var result struct {
+		ID int `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("https://gitlab.com/%s/%s/-/issues/%d#note_%d", owner, repo, number, result.ID), nil
+}
+
+// CreateAnonymousPRComment posts a note (comment) on a GitLab merge request.
+func (p *GitLabProvider) CreateAnonymousPRComment(owner, repo string, number int, body string) (string, error) {
+	t := token()
+	if t == "" {
+		return "", fmt.Errorf("GITLAB_TOKEN not set")
+	}
+
+	apiURL := fmt.Sprintf("https://gitlab.com/api/v4/projects/%s/merge_requests/%d/notes", projectID(owner, repo), number)
+
+	jsonData, err := json.Marshal(map[string]string{"body": body})
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequest("POST", apiURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return "", err
+	}
+	authHeader(req)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("failed to create GitLab MR note: %s", resp.Status)
+	}
+
+	var result struct {
+		ID int `json:"id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("https://gitlab.com/%s/%s/-/merge_requests/%d#note_%d", owner, repo, number, result.ID), nil
+}
+
+// IsRepoVerified checks if the GitLab repo has a .gitgost.yml file.
+func (p *GitLabProvider) IsRepoVerified(owner, repo string) bool {
+	apiURL := fmt.Sprintf("https://gitlab.com/api/v4/projects/%s/repository/files/.gitgost.yml/raw",
+		projectID(owner, repo))
+	resp, err := http.Get(apiURL)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1,0 +1,61 @@
+package provider
+
+// Ref represents a git reference (branch or tag) with its SHA.
+type Ref struct {
+	Ref string
+	SHA string
+}
+
+// RepoPolicy contains the directives read from .gitgost.yml in the target repository.
+type RepoPolicy struct {
+	DenyAll bool
+}
+
+// Provider abstracts the operations needed to anonymize contributions
+// across different git hosting platforms (GitHub, GitLab, etc.).
+type Provider interface {
+	// ForkRepo creates (or returns existing) fork of owner/repo.
+	// Returns the fork owner login/username.
+	ForkRepo(owner, repo string) (forkOwner string, err error)
+
+	// CreateMR creates a Merge/Pull Request from forkOwner:branch → owner/repo:main.
+	// Returns the HTML URL of the created MR/PR.
+	CreateMR(owner, repo, branch, forkOwner, commitMessage string) (url string, err error)
+
+	// GetRefs returns all refs (branches/tags) for the given repository.
+	GetRefs(owner, repo string) ([]Ref, error)
+
+	// GetExistingMR checks if an open MR/PR already exists from forkOwner:branchName.
+	// Returns (mrURL, branchExists, error).
+	GetExistingMR(owner, repo, forkOwner, branchName string) (mrURL string, branchExists bool, err error)
+
+	// CloseMRByURL closes an open MR/PR given its HTML URL.
+	CloseMRByURL(mrURL string) error
+
+	// GetRepoPolicy reads the .gitgost.yml policy file from the repository.
+	GetRepoPolicy(owner, repo string) (*RepoPolicy, error)
+
+	// IsRepoVerified checks if the repository has a .gitgost.yml file.
+	IsRepoVerified(owner, repo string) bool
+
+	// CloneURL returns the HTTPS clone URL for a repository.
+	CloneURL(owner, repo string) string
+
+	// PushURL returns the HTTPS push URL for a forked repository.
+	PushURL(forkOwner, repo string) string
+
+	// TokenEnvVar returns the name of the environment variable that holds the token.
+	TokenEnvVar() string
+
+	// Name returns a human-readable name for the provider (e.g. "GitHub", "GitLab").
+	Name() string
+
+	// CreateAnonymousIssue creates an issue and returns (issueURL, issueNumber, error).
+	CreateAnonymousIssue(owner, repo, title, body string, labels []string) (string, int, error)
+
+	// CreateAnonymousComment posts a comment on an issue and returns the comment URL.
+	CreateAnonymousComment(owner, repo string, number int, body string) (string, error)
+
+	// CreateAnonymousPRComment posts a comment on a PR/MR and returns the comment URL.
+	CreateAnonymousPRComment(owner, repo string, number int, body string) (string, error)
+}

--- a/web/index.html
+++ b/web/index.html
@@ -23,19 +23,19 @@
     <meta name="msapplication-TileColor" content="#d16014">
     <meta name="msapplication-TileImage" content="assets/logos/ms-icon-144x144.png">
     <meta name="theme-color" content="#d16014">
-    <meta name="description" content="Contribute to any GitHub repo without leaving a trace. Anonymous Git contributions with gitGost - privacy first, zero accounts, open source.">
+    <meta name="description" content="Contribute to any GitHub or GitLab repo without leaving a trace. Anonymous Git contributions with gitGost - privacy first, zero accounts, open source.">
     <meta name="keywords" content="anonymous git contributions, git privacy, github anonymous pr, open source git, gitgost, anonymous coding, privacy git, zero trace git, git contributions anonymous, gitgost app">
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://gitgost.fly.dev">
     <meta property="og:title" content="gitGost — Anonymous Git Contributions">
-    <meta property="og:description" content="Contribute to any GitHub repo without leaving a trace. Anonymous Git contributions with gitGost - privacy first, zero accounts, open source.">
+    <meta property="og:description" content="Contribute to any GitHub or GitLab repo without leaving a trace. Anonymous Git contributions with gitGost - privacy first, zero accounts, open source.">
     <meta property="og:image" content="https://gitgost.fly.dev/assets/logos/favicon.ico">
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://gitgost.fly.dev">
     <meta property="twitter:title" content="gitGost — Anonymous Git Contributions">
-    <meta property="twitter:description" content="Contribute to any GitHub repo without leaving a trace.">
+    <meta property="twitter:description" content="Contribute to any GitHub or GitLab repo without leaving a trace.">
     <meta property="twitter:image" content="https://gitgost.fly.dev/assets/logos/favicon.ico">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -978,10 +978,12 @@
     <main>
         <header>
             <h1>gitGost</h1>
-            <div class="tagline">Contribute to any GitHub repo without leaving a trace.</div>
+            <div class="tagline">Contribute to any GitHub or GitLab repo without leaving a trace.</div>
             <div class="badges">
                 <span class="badge">Privacy-first</span>
                 <span class="badge">Zero accounts</span>
+                <span class="badge">GitHub</span>
+                <span class="badge">GitLab</span>
                 <span class="badge">AGPL-3.0</span>
                 <span class="badge">Go-powered</span>
             </div>
@@ -989,13 +991,22 @@
 
         <section id="usage">
             <div class="terminal-tabs">
-                <button class="terminal-tab active" data-terminal="push">Push / PR</button>
-                <button class="terminal-tab" data-terminal="update">Update PR</button>
-                <button class="terminal-tab" data-terminal="fetch">Fetch / Pull</button>
+                <button class="terminal-tab active" data-terminal="push">Push</button>
+                <button class="terminal-tab" data-terminal="update">Update</button>
+                <button class="terminal-tab" data-terminal="fetch">Clone / Fetch / Pull</button>
                 <button class="terminal-tab" data-terminal="tor">Push via Tor</button>
                 <button class="terminal-tab" data-terminal="exif">Strip Metadata</button>
             </div>
-            <div class="terminal" id="terminal-push"><div class="terminal-titlebar"><span class="terminal-btn close"></span><span class="terminal-btn min"></span><span class="terminal-btn max"></span></div><div class="terminal-body"><span class="comment"># Add as remote → push → done. Fully anonymous.</span>
+            <p style="font-size:.82rem;color:var(--fg-secondary);margin:.75rem 0 .75rem;line-height:1.6;">
+                Use <code style="color:var(--accent);background:var(--code-bg);padding:.1em .4em;border-radius:4px;">/v1/gh/</code> for <strong style="color:var(--fg);">GitHub</strong> repos &nbsp;·&nbsp; <code style="color:#fc6d26;background:var(--code-bg);padding:.1em .4em;border-radius:4px;">/v1/gl/</code> for <strong style="color:var(--fg);">GitLab</strong> repos
+            </p>
+            <div class="terminal" id="terminal-push">
+                <div class="terminal-titlebar"><span class="terminal-btn close"></span><span class="terminal-btn min"></span><span class="terminal-btn max"></span></div>
+                <div style="display:flex;gap:.5rem;padding:0 0.875rem 0;padding-bottom: 14px;background:#252636;border-bottom:1px solid var(--border);">
+                    <button class="terminal-tab active" data-push-provider="gh" style="font-size:.8rem;padding:.35rem .75rem;">GitHub</button>
+                    <button class="terminal-tab" data-push-provider="gl" style="font-size:.8rem;padding:.35rem .75rem;">GitLab</button>
+                </div>
+                <div class="terminal-body" id="push-body-gh"><span class="comment"># Add as remote → push → done. Fully anonymous.</span>
 <span class="prompt">$</span> git remote add gost https://gitgost.fly.dev/v1/gh/torvalds/linux
 <span class="prompt">$</span> git checkout -b fix-typo
 <span class="prompt">$</span> git commit -am "fix: typo in documentation
@@ -1003,8 +1014,20 @@
 This commit fixes a grammatical error in the README.
 The word 'recieve' should be 'receive'."
 <span class="prompt">$</span> git push gost fix-typo:main
-<span class="success">→</span> Anonymized commit + PR opened as @gitgost-anonymous
+<span class="success">→</span> Anonymized commit + MR opened as @gitgost-anonymous
 <span class="success">→</span> PR Hash: <span class="hl">a3f8c1d2</span>  ← save this to update the PR later
+<span class="success">→</span> Subscribe to notifications (no account needed):
+<span class="success">→</span>   <span class="hl">https://ntfy.sh/gitgost-a3f8c1d2</span></div>
+                <div class="terminal-body" id="push-body-gl" style="display:none;"><span class="comment"># Use /v1/gl/ instead of /v1/gh/ for GitLab repos.</span>
+<span class="prompt">$</span> git remote add gost https://gitgost.fly.dev/v1/gl/torvalds/linux
+<span class="prompt">$</span> git checkout -b fix-typo
+<span class="prompt">$</span> git commit -am "fix: typo in documentation
+
+This commit fixes a grammatical error in the README.
+The word 'recieve' should be 'receive'."
+<span class="prompt">$</span> git push gost fix-typo:main
+<span class="success">→</span> Anonymized commit + MR opened as @gitgost-anonymous
+<span class="success">→</span> MR Hash: <span class="hl">a3f8c1d2</span>  ← save this to update the MR later
 <span class="success">→</span> Subscribe to notifications (no account needed):
 <span class="success">→</span>   <span class="hl">https://ntfy.sh/gitgost-a3f8c1d2</span></div>
             </div>
@@ -1015,10 +1038,23 @@ The word 'recieve' should be 'receive'."
 <span class="success">→</span> Existing branch force-updated, PR refreshed — still @gitgost-anonymous
 <span class="comment"># If the hash is unknown or the PR was closed, a new PR is created automatically.</span></div>
             </div>
-            <div class="terminal" id="terminal-fetch" style="display:none;"><div class="terminal-titlebar"><span class="terminal-btn close"></span><span class="terminal-btn min"></span><span class="terminal-btn max"></span></div><div class="terminal-body"><span class="comment"># Clone or fetch anonymously — no GitHub account needed.</span>
+            <div class="terminal" id="terminal-fetch" style="display:none;">
+                <div class="terminal-titlebar"><span class="terminal-btn close"></span><span class="terminal-btn min"></span><span class="terminal-btn max"></span></div>
+                <div style="display:flex;gap:.5rem;padding:0 0.875rem 0;padding-bottom: 14px;background:#252636;border-bottom:1px solid var(--border);">
+                    <button class="terminal-tab active" data-fetch-provider="gh" style="font-size:.8rem;padding:.35rem .75rem;">GitHub</button>
+                    <button class="terminal-tab" data-fetch-provider="gl" style="font-size:.8rem;padding:.35rem .75rem;">GitLab</button>
+                </div>
+                <div class="terminal-body" id="fetch-body-gh"><span class="comment"># Clone or fetch anonymously — no GitHub account needed.</span>
 <span class="prompt">$</span> git clone https://anon:@gitgost.fly.dev/v1/gh/torvalds/linux
 <span class="comment"># Or add as remote and fetch/pull later</span>
 <span class="prompt">$</span> git remote add gost https://anon:@gitgost.fly.dev/v1/gh/torvalds/linux
+<span class="prompt">$</span> git fetch gost
+<span class="prompt">$</span> git pull gost main
+<span class="success">→</span> Repository cloned with zero identity exposure</div>
+                <div class="terminal-body" id="fetch-body-gl" style="display:none;"><span class="comment"># Clone or fetch from GitLab anonymously — use /v1/gl/ prefix.</span>
+<span class="prompt">$</span> git clone https://anon:@gitgost.fly.dev/v1/gl/torvalds/linux
+<span class="comment"># Or add as remote and fetch/pull later</span>
+<span class="prompt">$</span> git remote add gost https://anon:@gitgost.fly.dev/v1/gl/torvalds/linux
 <span class="prompt">$</span> git fetch gost
 <span class="prompt">$</span> git pull gost main
 <span class="success">→</span> Repository cloned with zero identity exposure</div>
@@ -1181,7 +1217,7 @@ The word 'recieve' should be 'receive'."
             </div>
             <div class="card">
                 <h3>Fetch & Pull Support</h3>
-                <p>Clone, fetch, and pull from any GitHub repo through gitGost. Read code anonymously — no account, no trace.</p>
+                <p>Clone, fetch, and pull from any GitHub or GitLab repo through gitGost. Read code anonymously — no account, no trace.</p>
             </div>
             <div class="card">
                 <h3>Persistent PR Updates</h3>
@@ -1218,14 +1254,21 @@ The word 'recieve' should be 'receive'."
         <section class="issue-section">
             <div class="issue-container">
                 <div class="issue-header">
-                    <div class="issue-eyebrow">Anonymous issues, comments &amp; PR feedback</div>
-                    <p>Create issues, comment on them, or leave feedback on Pull Requests — all without exposing your identity. We only keep what's essential: URL, anonymous hash, and <a href="/karma.html" style="color: var(--accent);">karma</a>.</p>
+                    <div class="issue-eyebrow">Anonymous issues, comments &amp; PR/MR feedback</div>
+                    <p>Create issues, comment on them, or leave feedback on Pull Requests and Merge Requests — all without exposing your identity. We only keep what's essential: URL, anonymous hash, and <a href="/karma.html" style="color: var(--accent);">karma</a>.</p>
+                    <div style="display:flex;align-items:center;gap:.5rem;margin-top:.75rem;">
+                        <span style="font-size:.8rem;color:var(--fg-secondary);">Provider:</span>
+                        <select id="issue-provider" style="background:var(--bg-secondary);color:var(--fg);border:1px solid var(--border);border-radius:6px;padding:.25rem .6rem;font-size:.8rem;cursor:pointer;">
+                            <option value="gh">GitHub</option>
+                            <option value="gl">GitLab</option>
+                        </select>
+                    </div>
                 </div>
 
                 <div class="issue-tabs">
                     <button class="issue-tab active" data-tab="create">Create Issue</button>
                     <button class="issue-tab" data-tab="comment">Post Comment</button>
-                    <button class="issue-tab" data-tab="pr-comment">PR Comment</button>
+                    <button class="issue-tab" data-tab="pr-comment" id="pr-comment-tab">PR Comment</button>
                 </div>
 
                 <div class="issue-form-container">
@@ -1327,7 +1370,7 @@ The word 'recieve' should be 'receive'."
                         </div>
 
                         <div class="form-group">
-                            <label for="pr-number">Pull Request Number</label>
+                            <label for="pr-number" id="pr-number-label">Pull Request Number</label>
                             <input id="pr-number" type="number" min="1" placeholder="42" autocomplete="off">
                         </div>
 
@@ -1708,7 +1751,17 @@ The word 'recieve' should be 'receive'."
             });
         })();
 
+        // Update PR tab label and field label when provider changes
+        document.getElementById('issue-provider')?.addEventListener('change', () => {
+            const gl = document.getElementById('issue-provider').value === 'gl';
+            const tab = document.getElementById('pr-comment-tab');
+            const label = document.getElementById('pr-number-label');
+            if (tab) tab.textContent = gl ? 'MR Comment' : 'PR Comment';
+            if (label) label.textContent = gl ? 'Merge Request Number' : 'Pull Request Number';
+        });
+
         issueSubmitBtn?.addEventListener('click', async () => {
+            const provider = document.getElementById('issue-provider')?.value || 'gh';
             const owner = document.getElementById('issue-owner')?.value.trim();
             const repo = document.getElementById('issue-repo')?.value.trim();
             const title = document.getElementById('issue-title')?.value.trim();
@@ -1729,7 +1782,7 @@ The word 'recieve' should be 'receive'."
             if (resultEl) resultEl.textContent = '';
 
             try {
-                const response = await fetch(`${API_BASE}/v1/gh/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues/anonymous`, {
+                const response = await fetch(`${API_BASE}/v1/${provider}/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues/anonymous`, {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',
@@ -1764,6 +1817,7 @@ The word 'recieve' should be 'receive'."
         });
 
         commentSubmitBtn?.addEventListener('click', async () => {
+            const provider = document.getElementById('issue-provider')?.value || 'gh';
             const owner = document.getElementById('comment-owner')?.value.trim();
             const repo = document.getElementById('comment-repo')?.value.trim();
             const number = document.getElementById('comment-number')?.value.trim();
@@ -1785,7 +1839,7 @@ The word 'recieve' should be 'receive'."
             if (token) payload.user_token = token;
 
             try {
-                const response = await fetch(`${API_BASE}/v1/gh/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues/${encodeURIComponent(number)}/comments/anonymous`, {
+                const response = await fetch(`${API_BASE}/v1/${provider}/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues/${encodeURIComponent(number)}/comments/anonymous`, {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',
@@ -1821,6 +1875,7 @@ The word 'recieve' should be 'receive'."
         const prCommentSubmitBtn = document.getElementById('pr-comment-submit');
         document.getElementById('pr-comment-issue-form')?.addEventListener('submit', async (e) => {
             e.preventDefault();
+            const provider = document.getElementById('issue-provider')?.value || 'gh';
             const owner = document.getElementById('pr-owner')?.value.trim();
             const repo = document.getElementById('pr-repo')?.value.trim();
             const number = document.getElementById('pr-number')?.value.trim();
@@ -1842,7 +1897,7 @@ The word 'recieve' should be 'receive'."
             if (token) payload.user_token = token;
 
             try {
-                const response = await fetch(`${API_BASE}/v1/gh/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls/${encodeURIComponent(number)}/comments/anonymous`, {
+                const response = await fetch(`${API_BASE}/v1/${provider}/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls/${encodeURIComponent(number)}/comments/anonymous`, {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',
@@ -1950,6 +2005,28 @@ The word 'recieve' should be 'receive'."
                 document.getElementById('tor-linux').style.display = target === 'linux' ? '' : 'none';
                 document.getElementById('tor-windows-browser').style.display = target === 'windows-browser' ? '' : 'none';
                 document.getElementById('tor-windows-wsl').style.display = target === 'windows-wsl' ? '' : 'none';
+            });
+        });
+
+        // Push provider sub-tab switching (GitHub / GitLab)
+        document.querySelectorAll('[data-push-provider]').forEach(tab => {
+            tab.addEventListener('click', () => {
+                document.querySelectorAll('[data-push-provider]').forEach(t => t.classList.remove('active'));
+                tab.classList.add('active');
+                const p = tab.dataset.pushProvider;
+                document.getElementById('push-body-gh').style.display = p === 'gh' ? '' : 'none';
+                document.getElementById('push-body-gl').style.display = p === 'gl' ? '' : 'none';
+            });
+        });
+
+        // Fetch provider sub-tab switching (GitHub / GitLab)
+        document.querySelectorAll('[data-fetch-provider]').forEach(tab => {
+            tab.addEventListener('click', () => {
+                document.querySelectorAll('[data-fetch-provider]').forEach(t => t.classList.remove('active'));
+                tab.classList.add('active');
+                const p = tab.dataset.fetchProvider;
+                document.getElementById('fetch-body-gh').style.display = p === 'gh' ? '' : 'none';
+                document.getElementById('fetch-body-gl').style.display = p === 'gl' ? '' : 'none';
             });
         });
 


### PR DESCRIPTION
Agregado soporte completo para GitLab mediante arquitectura de providers unificada. Creada interfaz provider.Provider en internal/provider/provider.go con métodos ForkRepo, CreateMR, GetRefs, GetExistingMR, CloseMRByURL, GetRepoPolicy, IsRepoVerified, CloneURL, PushURL, TokenEnvVar, Name, CreateAnonymousIssue, CreateAnonymousComment y CreateAnonymousPRComment. Implementados adapters GitHubProvider (internal/provider/github/) y GitLabProvider (internal/provider/gitlab/) con lógica específ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitLab support alongside existing GitHub functionality, enabling users to anonymize contributions across both platforms.
  * Introduced provider selector in the UI to switch between GitHub and GitLab workflows.
  * Updated terminal examples and documentation to demonstrate both GitHub and GitLab operations.
  * Added `GITLAB_TOKEN` environment variable support for GitLab authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->