### PR TITLE
Add anonymous appeal system for blocked hashes

### DIFF
--- a/internal/github/ntfy.go
+++ b/internal/github/ntfy.go
@@ -33,7 +33,9 @@ func NtfyServiceURL() string {
 }
 
 // PublishNtfyEvent publishes an event to the ntfy topic corresponding to a PR hash.
-func PublishNtfyEvent(prHash, title, message string) error {
+// actions: optional ntfy Actions header value (e.g. a button to check PR status).
+// Pass empty string to send without action buttons.
+func PublishNtfyEvent(prHash, title, message, actions string) error {
 	topic := NtfyTopicForPR(prHash)
 	url := fmt.Sprintf("%s/%s", NtfyBaseURL(), topic)
 
@@ -44,6 +46,9 @@ func PublishNtfyEvent(prHash, title, message string) error {
 	req.Header.Set("Title", title)
 	req.Header.Set("Tags", "bell")
 	req.Header.Set("Content-Type", "text/plain; charset=utf-8")
+	if actions != "" {
+		req.Header.Set("Actions", actions)
+	}
 
 	resp, err := ntfyClient.Do(req)
 	if err != nil {

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -716,12 +717,135 @@ func IsRepoVerified(owner, repo string) bool {
 	return resp.StatusCode == 200
 }
 
-// GeneratePRHash genera un hash determinístico de 8 caracteres basado en owner/repo/branch.
+// GeneratePRHash genera un hash deterministico de 8 caracteres basado en owner/repo/branch.
 // Esto permite que el mismo branch siempre produzca el mismo pr-hash, sin almacenar estado.
 func GeneratePRHash(owner, repo, branch string) string {
 	input := fmt.Sprintf("%s/%s/%s", owner, repo, branch)
 	sum := sha256.Sum256([]byte(input))
 	return hex.EncodeToString(sum[:])[:8]
+}
+
+// PRTimelineEvent representa un evento individual del timeline de un PR.
+// Solo contiene los campos que nos interesan.
+type PRTimelineEvent struct {
+	Event     string `json:"event"`
+	CreatedAt string `json:"created_at"`
+	Body      string `json:"body,omitempty"`
+	User      *struct {
+		Login string `json:"login"`
+	} `json:"user,omitempty"`
+	State string `json:"state,omitempty"`
+	Label *struct {
+		Name string `json:"name"`
+	} `json:"label,omitempty"`
+}
+
+// ExtractPRNumber extrae el numero de PR de una URL de GitHub.
+// Formato esperado: https://github.com/{owner}/{repo}/pull/{number}
+func ExtractPRNumber(prURL string) int {
+	parts := strings.Split(strings.TrimPrefix(prURL, "https://github.com/"), "/")
+	if len(parts) < 4 || parts[2] != "pull" {
+		return 0
+	}
+	n, err := strconv.Atoi(parts[3])
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+// FetchPRTimeline obtiene el timeline de un PR desde la API de GitHub.
+// Usa ETag/If-None-Match para evitar datos innecesarios.
+// Retorna los eventos, el nuevo ETag, si hubo cambios, o error.
+func FetchPRTimeline(owner, repo string, number int, etag string) (events []PRTimelineEvent, newETag string, changed bool, err error) {
+	token := os.Getenv("GITHUB_TOKEN")
+	if token == "" {
+		return nil, "", false, fmt.Errorf("GITHUB_TOKEN not set")
+	}
+
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/issues/%d/timeline?per_page=100", owner, repo, number)
+
+	req, err := http.NewRequest("GET", apiURL, nil)
+	if err != nil {
+		return nil, "", false, err
+	}
+	req.Header.Set("Authorization", "token "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "gitGost")
+	if etag != "" {
+		req.Header.Set("If-None-Match", etag)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, "", false, err
+	}
+	defer resp.Body.Close()
+
+	newETag = resp.Header.Get("ETag")
+
+	if resp.StatusCode == http.StatusNotModified {
+		return nil, newETag, false, nil
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", false, fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&events); err != nil {
+		return nil, "", false, err
+	}
+
+	// GitHub puede devolver null en lugar de array
+	if events == nil {
+		events = []PRTimelineEvent{}
+	}
+
+	return events, newETag, true, nil
+}
+
+// FetchPRInfo obtiene informacion basica del PR (state, title, comments count).
+// Usa el endpoint de issues ya que los PRs son issues.
+func FetchPRInfo(owner, repo string, number int) (state, title string, comments int, updatedAt string, err error) {
+	token := os.Getenv("GITHUB_TOKEN")
+	if token == "" {
+		return "", "", 0, "", fmt.Errorf("GITHUB_TOKEN not set")
+	}
+
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/issues/%d", owner, repo, number)
+
+	req, err := http.NewRequest("GET", apiURL, nil)
+	if err != nil {
+		return "", "", 0, "", err
+	}
+	req.Header.Set("Authorization", "token "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "gitGost")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", "", 0, "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", "", 0, "", fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
+	}
+
+	var result struct {
+		State     string `json:"state"`
+		Title     string `json:"title"`
+		Comments  int    `json:"comments"`
+		UpdatedAt string `json:"updated_at"`
+		// El campo pull_request existe solo si es un PR
+		PullRequest *struct{} `json:"pull_request,omitempty"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", "", 0, "", err
+	}
+
+	return result.State, result.Title, result.Comments, result.UpdatedAt, nil
 }
 
 // GetExistingPR busca si existe un PR abierto desde forkOwner:branchName hacia owner/repo.

--- a/internal/http/appeal.go
+++ b/internal/http/appeal.go
@@ -4,6 +4,7 @@ import (
 	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/hex"
 	"fmt"
 	"html/template"
@@ -220,20 +221,35 @@ func AppealViewHandler(c *gin.Context) {
 
 	appealTicketsMu.Lock()
 	ticket, exists := appealTickets[ticketID]
+	// Snapshot mutable fields under lock to avoid races with admin/POST updates.
+	var (
+		hash      string
+		createdAt time.Time
+		resolved  bool
+		unbanned  bool
+		message   string
+	)
+	if exists {
+		hash = ticket.Hash
+		createdAt = ticket.CreatedAt
+		resolved = ticket.Resolved
+		unbanned = ticket.Unbanned
+		message = ticket.Message
+	}
 	appealTicketsMu.Unlock()
 
-	if !exists || time.Since(ticket.CreatedAt) > appealTicketTTL {
+	if !exists || time.Since(createdAt) > appealTicketTTL {
 		c.String(http.StatusNotFound, "Appeal not found or expired.")
 		return
 	}
 
 	if c.Request.Method == http.MethodPost {
-		message := strings.TrimSpace(c.PostForm("message"))
-		if message == "" {
+		msg := strings.TrimSpace(c.PostForm("message"))
+		if msg == "" {
 			_ = appealStartTmpl.Execute(c.Writer, gin.H{
 				"Title":    "Submit appeal",
 				"Subtitle": "Your appeal message cannot be empty.",
-				"Hash":     ticket.Hash,
+				"Hash":     hash,
 				"TicketID": ticketID,
 				"Error":    "Message is required.",
 			})
@@ -241,27 +257,29 @@ func AppealViewHandler(c *gin.Context) {
 		}
 
 		appealTicketsMu.Lock()
-		ticket.Message = message
+		if t, ok := appealTickets[ticketID]; ok {
+			t.Message = msg
+		}
 		appealTicketsMu.Unlock()
 
 		// Notify admin via ntfy if configured
 		if ntfyAdminTopic != "" {
-			go notifyAdminAppeal(ticketID, ticket.Hash)
+			go notifyAdminAppeal(ticketID, hash)
 		}
 
 		_ = appealStartTmpl.Execute(c.Writer, gin.H{
 			"Title":    "Appeal submitted",
 			"Subtitle": "Your appeal has been received.",
-			"Hash":     ticket.Hash,
+			"Hash":     hash,
 			"Done":     true,
 		})
 		return
 	}
 
 	// GET: show the appeal form or status
-	if ticket.Resolved {
-		status := "closed"
-		if ticket.Unbanned {
+	if resolved {
+		var status string
+		if unbanned {
 			status = "approved — hash unbanned"
 		} else {
 			status = "dismissed — ban upheld"
@@ -269,19 +287,19 @@ func AppealViewHandler(c *gin.Context) {
 		_ = appealStartTmpl.Execute(c.Writer, gin.H{
 			"Title":    "Appeal resolved",
 			"Subtitle": "Status: " + status,
-			"Hash":     ticket.Hash,
+			"Hash":     hash,
 			"Done":     true,
 			"Resolved": true,
-			"Unbanned": ticket.Unbanned,
+			"Unbanned": unbanned,
 		})
 		return
 	}
 
-	if ticket.Message != "" {
+	if message != "" {
 		_ = appealStartTmpl.Execute(c.Writer, gin.H{
 			"Title":    "Appeal submitted",
 			"Subtitle": "Waiting for admin review.",
-			"Hash":     ticket.Hash,
+			"Hash":     hash,
 			"Done":     true,
 		})
 		return
@@ -290,7 +308,7 @@ func AppealViewHandler(c *gin.Context) {
 	_ = appealStartTmpl.Execute(c.Writer, gin.H{
 		"Title":    "Submit appeal",
 		"Subtitle": "Explain why your content should be unbanned.",
-		"Hash":     ticket.Hash,
+		"Hash":     hash,
 		"TicketID": ticketID,
 	})
 }
@@ -313,12 +331,13 @@ func notifyAdminAppeal(ticketID, hash string) {
 // AdminAppealsHandler lista las apelaciones abiertas (protegido por password).
 func AdminAppealsHandler(c *gin.Context) {
 	password := c.Query("password")
-	if password == "" || panicPassword == "" || password != panicPassword {
+	if password == "" {
+		password, _ = c.Cookie("admin_pass")
+	}
+	if password == "" || panicPassword == "" || subtle.ConstantTimeCompare([]byte(password), []byte(panicPassword)) != 1 {
 		c.String(http.StatusUnauthorized, "Unauthorized")
 		return
 	}
-	escapedPassword := template.HTMLEscapeString(password)
-
 	appealTicketsMu.Lock()
 	type appealView struct {
 		TicketID  string
@@ -376,19 +395,26 @@ button.dismiss{border-color:#f85149;color:#f85149;}
 			msgPreview = msgPreview[:60] + "..."
 		}
 		age := time.Since(v.CreatedAt).Round(time.Minute)
+		// Escape every dynamic value to prevent stored/reflected XSS.
+		ticketID := template.HTMLEscapeString(v.TicketID)
+		ticketShort := template.HTMLEscapeString(v.TicketID[:8])
+		hash := template.HTMLEscapeString(v.Hash)
+		msg := template.HTMLEscapeString(msgPreview)
+		ageStr := template.HTMLEscapeString(age.String())
+		pwd := template.HTMLEscapeString(password)
 		fmt.Fprintf(c.Writer, `<tr><td><a href="/appeal/%s">%s</a></td><td>%s</td><td>%s</td><td>%s</td>
-<td>
-<form method="POST" action="/admin/appeals/%s/resolve" style="display:inline;">
-<input type="hidden" name="password" value="%s">
-<input type="hidden" name="outcome" value="unban">
-<button type="submit" class="unban">Unban</button>
-</form>
-<form method="POST" action="/admin/appeals/%s/resolve" style="display:inline;">
-<input type="hidden" name="password" value="%s">
-<input type="hidden" name="outcome" value="dismiss">
-<button type="submit" class="dismiss">Dismiss</button>
-</form>
-</td></tr>`, v.TicketID, v.TicketID[:8], template.HTMLEscapeString(v.Hash), msgPreview, age, v.TicketID, escapedPassword, v.TicketID, escapedPassword)
+	<td>
+	<form method="POST" action="/admin/appeals/%s/resolve" style="display:inline;">
+	<input type="hidden" name="password" value="%s">
+	<input type="hidden" name="outcome" value="unban">
+	<button type="submit" class="unban">Unban</button>
+	</form>
+	<form method="POST" action="/admin/appeals/%s/resolve" style="display:inline;">
+	<input type="hidden" name="password" value="%s">
+	<input type="hidden" name="outcome" value="dismiss">
+	<button type="submit" class="dismiss">Dismiss</button>
+	</form>
+	</td></tr>`, ticketID, ticketShort, hash, msg, ageStr, ticketID, pwd, ticketID, pwd)
 	}
 	fmt.Fprintf(c.Writer, `</table>
 <hr class="sep"><h2>Resolved (%d)</h2><table><tr><th>Ticket</th><th>Hash</th><th>Outcome</th></tr>`, len(resolvedList))
@@ -400,7 +426,9 @@ button.dismiss{border-color:#f85149;color:#f85149;}
 		if v.Unbanned {
 			outcome = `<span class="tag tag-open">unbanned</span>`
 		}
-		fmt.Fprintf(c.Writer, `<tr><td>%s</td><td>%s</td><td>%s</td></tr>`, v.TicketID[:8], template.HTMLEscapeString(v.Hash), outcome)
+		ticketShort := template.HTMLEscapeString(v.TicketID[:8])
+		hash := template.HTMLEscapeString(v.Hash)
+		fmt.Fprintf(c.Writer, `<tr><td>%s</td><td>%s</td><td>%s</td></tr>`, ticketShort, hash, outcome)
 	}
 	fmt.Fprintf(c.Writer, `</table></body></html>`)
 }
@@ -411,7 +439,7 @@ func AdminAppealResolveHandler(c *gin.Context) {
 	password := c.PostForm("password")
 	outcome := c.PostForm("outcome")
 
-	if password == "" || panicPassword == "" || password != panicPassword {
+	if password == "" || panicPassword == "" || subtle.ConstantTimeCompare([]byte(password), []byte(panicPassword)) != 1 {
 		c.String(http.StatusUnauthorized, "Unauthorized")
 		return
 	}
@@ -427,14 +455,20 @@ func AdminAppealResolveHandler(c *gin.Context) {
 	ticket.Resolved = true
 	if outcome == "unban" {
 		ticket.Unbanned = true
-		// Remove from blocked hashes
-		delete(blockedHashes, ticket.Hash)
 		utils.Log("Appeal %s: hash %s unbanned", ticketID[:8], ticket.Hash)
 	} else {
 		ticket.Unbanned = false
 		utils.Log("Appeal %s: hash %s ban upheld", ticketID[:8], ticket.Hash)
 	}
+	hash := ticket.Hash
+	unbanned := outcome == "unban"
 	appealTicketsMu.Unlock()
+
+	if unbanned {
+		identityMu.Lock()
+		delete(blockedHashes, hash)
+		identityMu.Unlock()
+	}
 
 	// Send ntfy notification about resolution
 	if ntfyAdminTopic != "" && ticket.Message != "" {
@@ -451,5 +485,6 @@ func AdminAppealResolveHandler(c *gin.Context) {
 		}()
 	}
 
-	c.Redirect(http.StatusSeeOther, fmt.Sprintf("/admin/appeals?password=%s", password))
+	c.SetCookie("admin_pass", password, 3600, "/admin/", "", false, true)
+	c.Redirect(http.StatusSeeOther, "/admin/appeals")
 }

--- a/internal/http/appeal.go
+++ b/internal/http/appeal.go
@@ -1,0 +1,454 @@
+package http
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"html/template"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/livrasand/gitGost/internal/utils"
+)
+
+// --- Data structures ---
+
+// appealTicket stores an anonymous appeal ticket linked to a hash.
+type appealTicket struct {
+	Hash      string
+	Message   string
+	CreatedAt time.Time
+	Resolved  bool
+	Unbanned  bool
+}
+
+var (
+	appealTicketsMu sync.Mutex
+	appealTickets   = make(map[string]*appealTicket)
+	appealTicketTTL = 7 * 24 * time.Hour
+)
+
+// --- Template ---
+
+var appealStartTmpl = template.Must(template.New("appealStart").Parse(appealHTML))
+
+const appealHTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>Appeal · gitGost</title>
+<style>
+body{font-family:Inter,system-ui,-apple-system,Segoe UI,sans-serif;background:#0d1117;color:#c9d1d9;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;padding:32px;}
+.shell{background:linear-gradient(145deg,rgba(255,166,87,0.16),rgba(255,107,107,0.14));border:1px solid rgba(255,166,87,0.45);border-radius:16px;padding:1.5px;box-shadow:0 16px 38px rgba(0,0,0,.42);max-width:620px;width:100%;}
+.card{background:#0d1117;border-radius:14px;padding:26px;border:1px solid rgba(255,255,255,0.05);}
+h1{margin:0 0 6px;font-size:24px;color:#ffa657;}
+.eyebrow{display:inline-flex;align-items:center;gap:.35rem;padding:.35rem .75rem;background:rgba(255,166,87,0.12);color:#ffa657;border:1px solid rgba(255,166,87,0.4);border-radius:999px;font-family:'IBM Plex Mono',monospace;font-size:.85rem;margin-bottom:5px;}
+.sub{margin:6px 0 14px;color:#9fb3ff;font-size:14px;}
+label{display:block;font-weight:700;margin:12px 0 6px;letter-spacing:.01em;}
+input[type=text]{width:100%;padding:12px;border-radius:10px;border:1px solid rgba(255,255,255,0.08);background:rgba(255,255,255,0.04);color:#c9d1d9;font-family:'IBM Plex Mono',monospace;}
+button{margin-top:14px;width:100%;padding:12px;border-radius:10px;border:none;background:linear-gradient(135deg,#ffa657,#ff6b6b);color:#0d1117;font-weight:700;font-size:15px;cursor:pointer;box-shadow:0 10px 30px rgba(0,0,0,0.25);}
+.note{margin-top:10px;font-size:12px;color:#9fb3ff;}
+.error{color:#ffb4c4;font-size:13px;margin-top:10px;}
+.info{background:rgba(255,255,255,0.03);border:1px solid rgba(255,255,255,0.05);border-radius:12px;padding:14px;margin:14px 0;font-size:13px;line-height:1.55;}
+.info strong{color:#ffa657;}
+.secret-url{background:rgba(255,166,87,0.08);border:1px solid #ffa657;border-radius:10px;padding:14px;margin:14px 0;word-break:break-all;font-family:'IBM Plex Mono',monospace;font-size:13px;color:#ffa657;}
+a{color:#9fb3ff;}
+.muted{color:#8b949e;font-size:12px;margin-top:8px;}
+textarea{width:100%;min-height:120px;padding:12px;border-radius:10px;border:1px solid rgba(255,255,255,0.08);background:rgba(255,255,255,0.04);color:#c9d1d9;font-family:'IBM Plex Mono',monospace;resize:vertical;}
+</style>
+</head>
+<body>
+<div class="shell"><div class="card">
+<div class="eyebrow">Anonymous appeal</div>
+<h1>{{.Title}}</h1>
+<div class="sub">{{.Subtitle}}</div>
+{{if .Error}}<div class="error">{{.Error}}</div>{{end}}
+{{if .SecretURL}}
+<div class="info"><strong>Save this link!</strong> This is your only way to access the appeal. If you lose it, it cannot be recovered.</div>
+<div class="secret-url">{{.SecretURL}}</div>
+<div class="muted">Bookmark it now. You will need it to submit your appeal message.</div>
+{{else if .Done}}
+<div class="info"><strong>Appeal {{if .Resolved}}resolved{{else}}submitted{{end}}.</strong>
+{{if .Resolved}}
+  {{if .Unbanned}}The hash has been <strong>unbanned</strong>. You can create content again.{{else}}The ban has been <strong>upheld</strong>. This decision is final.{{end}}
+{{else}}An admin will review it. Check back at your secret link for updates.{{end}}
+</div>
+{{else if .TicketID}}
+<form method="POST" action="/appeal/{{.TicketID}}">
+<label for="msg">Your appeal message</label>
+<textarea id="msg" name="message" placeholder="Explain why your content should be unbanned. Be specific and respectful." required>{{.Message}}</textarea>
+<button type="submit">Submit appeal</button>
+</form>
+<div class="muted">Your identity stays anonymous. No personal data is collected.</div>
+{{else}}
+<div class="info">Your hash <strong>{{.Hash}}</strong> is <strong>blocked</strong> (6+ reports).<br>To appeal, enter your <strong>appeal token</strong> — you received it when you created the content that produced this hash.</div>
+<form method="POST" action="/appeal">
+<label for="hash">Hash</label>
+<input type="text" id="hash" name="hash" value="{{.Hash}}" readonly />
+<label for="appeal_token">Appeal token</label>
+<input type="text" id="appeal_token" name="appeal_token" placeholder="Paste your appeal token here" autocomplete="off" />
+<button type="submit">Verify &amp; create appeal</button>
+</form>
+{{end}}
+<div class="note"><a href="/v1/moderation/report?hash={{.Hash}}">Back to report page</a> &middot; <a href="https://gitgost.fly.dev/">gitGost</a></div>
+</div></div>
+</body>
+</html>`
+
+// --- Token functions ---
+
+// generateAppealToken creates a deterministic token that proves ownership of a hash.
+// The token is HMAC("appeal:"+hash, serverSecretKey) — no storage needed.
+func generateAppealToken(hash string) string {
+	if hash == "" {
+		return ""
+	}
+	h := hmac.New(sha256.New, getSecretKey())
+	h.Write([]byte("appeal:" + hash))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// verifyAppealToken checks whether a token is valid proof of ownership for the given hash.
+func verifyAppealToken(hash, token string) bool {
+	if hash == "" || token == "" {
+		return false
+	}
+	expected := generateAppealToken(hash)
+	return hmac.Equal([]byte(expected), []byte(token))
+}
+
+// --- Handlers ---
+
+// AppealStartHandler maneja GET/POST /appeal para iniciar una apelacion.
+func AppealStartHandler(c *gin.Context) {
+	if c.Request.Method == http.MethodGet {
+		hash := strings.TrimSpace(c.Query("hash"))
+		if hash == "" {
+			_ = appealStartTmpl.Execute(c.Writer, gin.H{
+				"Title":    "Appeal a ban",
+				"Subtitle": "Enter the blocked hash to start an appeal.",
+				"Hash":     "",
+				"Error":    "",
+			})
+			return
+		}
+		if !isBlockedHash(hash) {
+			_ = appealStartTmpl.Execute(c.Writer, gin.H{
+				"Title":    "Hash not blocked",
+				"Subtitle": "This hash is not currently blocked.",
+				"Hash":     hash,
+				"Error":    "This hash has fewer than 6 reports and is not blocked. No appeal needed.",
+			})
+			return
+		}
+		_ = appealStartTmpl.Execute(c.Writer, gin.H{
+			"Title":    "Appeal a ban",
+			"Subtitle": "Verify ownership to start an anonymous appeal.",
+			"Hash":     hash,
+		})
+		return
+	}
+
+	// POST: verify appeal_token and create ticket
+	hash := strings.TrimSpace(c.PostForm("hash"))
+	token := strings.TrimSpace(c.PostForm("appeal_token"))
+
+	if hash == "" || token == "" {
+		_ = appealStartTmpl.Execute(c.Writer, gin.H{
+			"Title":    "Missing fields",
+			"Subtitle": "Both hash and appeal token are required.",
+			"Hash":     hash,
+			"Error":    "Hash and appeal token are required.",
+		})
+		return
+	}
+
+	if !isBlockedHash(hash) {
+		_ = appealStartTmpl.Execute(c.Writer, gin.H{
+			"Title":    "Hash not blocked",
+			"Subtitle": "This hash is not currently blocked.",
+			"Hash":     hash,
+			"Error":    "This hash has fewer than 6 reports. No appeal needed.",
+		})
+		return
+	}
+
+	if !verifyAppealToken(hash, token) {
+		_ = appealStartTmpl.Execute(c.Writer, gin.H{
+			"Title":    "Invalid token",
+			"Subtitle": "The appeal token does not match this hash.",
+			"Hash":     hash,
+			"Error":    "Invalid appeal token. Make sure you are using the exact token you received when creating the content.",
+		})
+		return
+	}
+
+	// Generate ticket
+	b := make([]byte, 20)
+	if _, err := rand.Read(b); err != nil {
+		c.String(http.StatusInternalServerError, "Error creating appeal")
+		return
+	}
+	ticketID := hex.EncodeToString(b)
+
+	appealTicketsMu.Lock()
+	appealTickets[ticketID] = &appealTicket{
+		Hash:      hash,
+		CreatedAt: time.Now(),
+	}
+	appealTicketsMu.Unlock()
+
+	scheme := getScheme(c.Request)
+	secretURL := fmt.Sprintf("%s://%s/appeal/%s", scheme, c.Request.Host, ticketID)
+
+	_ = appealStartTmpl.Execute(c.Writer, gin.H{
+		"Title":     "Appeal created",
+		"Subtitle":  "Your anonymous appeal ticket is ready.",
+		"Hash":      hash,
+		"SecretURL": secretURL,
+	})
+}
+
+// AppealViewHandler maneja GET/POST /appeal/:ticket para ver y enviar el mensaje de apelacion.
+func AppealViewHandler(c *gin.Context) {
+	ticketID := c.Param("ticket")
+
+	appealTicketsMu.Lock()
+	ticket, exists := appealTickets[ticketID]
+	appealTicketsMu.Unlock()
+
+	if !exists || time.Since(ticket.CreatedAt) > appealTicketTTL {
+		c.String(http.StatusNotFound, "Appeal not found or expired.")
+		return
+	}
+
+	if c.Request.Method == http.MethodPost {
+		message := strings.TrimSpace(c.PostForm("message"))
+		if message == "" {
+			_ = appealStartTmpl.Execute(c.Writer, gin.H{
+				"Title":    "Submit appeal",
+				"Subtitle": "Your appeal message cannot be empty.",
+				"Hash":     ticket.Hash,
+				"TicketID": ticketID,
+				"Error":    "Message is required.",
+			})
+			return
+		}
+
+		appealTicketsMu.Lock()
+		ticket.Message = message
+		appealTicketsMu.Unlock()
+
+		// Notify admin via ntfy if configured
+		if ntfyAdminTopic != "" {
+			go notifyAdminAppeal(ticketID, ticket.Hash)
+		}
+
+		_ = appealStartTmpl.Execute(c.Writer, gin.H{
+			"Title":    "Appeal submitted",
+			"Subtitle": "Your appeal has been received.",
+			"Hash":     ticket.Hash,
+			"Done":     true,
+		})
+		return
+	}
+
+	// GET: show the appeal form or status
+	if ticket.Resolved {
+		status := "closed"
+		if ticket.Unbanned {
+			status = "approved — hash unbanned"
+		} else {
+			status = "dismissed — ban upheld"
+		}
+		_ = appealStartTmpl.Execute(c.Writer, gin.H{
+			"Title":    "Appeal resolved",
+			"Subtitle": "Status: " + status,
+			"Hash":     ticket.Hash,
+			"Done":     true,
+			"Resolved": true,
+			"Unbanned": ticket.Unbanned,
+		})
+		return
+	}
+
+	if ticket.Message != "" {
+		_ = appealStartTmpl.Execute(c.Writer, gin.H{
+			"Title":    "Appeal submitted",
+			"Subtitle": "Waiting for admin review.",
+			"Hash":     ticket.Hash,
+			"Done":     true,
+		})
+		return
+	}
+
+	_ = appealStartTmpl.Execute(c.Writer, gin.H{
+		"Title":    "Submit appeal",
+		"Subtitle": "Explain why your content should be unbanned.",
+		"Hash":     ticket.Hash,
+		"TicketID": ticketID,
+	})
+}
+
+// notifyAdminAppeal sends a ntfy notification when a new appeal is filed.
+func notifyAdminAppeal(ticketID, hash string) {
+	if ntfyAdminTopic == "" {
+		return
+	}
+	appealURL := fmt.Sprintf("https://gitgost.fly.dev/appeal/%s", ticketID)
+	payload := fmt.Sprintf(`{"topic":"%s","title":"New appeal filed","message":"Hash %s has filed an appeal.\n\n%s","tags":["warning"]}`, ntfyAdminTopic, hash, appealURL)
+	resp, err := http.Post("https://ntfy.sh", "application/json", strings.NewReader(payload))
+	if err != nil {
+		utils.Log("Error sending ntfy appeal notification: %v", err)
+		return
+	}
+	resp.Body.Close()
+}
+
+// AdminAppealsHandler lista las apelaciones abiertas (protegido por password).
+func AdminAppealsHandler(c *gin.Context) {
+	password := c.Query("password")
+	if password == "" || panicPassword == "" || password != panicPassword {
+		c.String(http.StatusUnauthorized, "Unauthorized")
+		return
+	}
+
+	appealTicketsMu.Lock()
+	type appealView struct {
+		TicketID  string
+		Hash      string
+		Message   string
+		CreatedAt time.Time
+		Resolved  bool
+		Unbanned  bool
+	}
+	var openList, resolvedList []appealView
+	for id, t := range appealTickets {
+		v := appealView{
+			TicketID:  id,
+			Hash:      t.Hash,
+			Message:   t.Message,
+			CreatedAt: t.CreatedAt,
+			Resolved:  t.Resolved,
+			Unbanned:  t.Unbanned,
+		}
+		if t.Resolved {
+			resolvedList = append(resolvedList, v)
+		} else {
+			openList = append(openList, v)
+		}
+	}
+	appealTicketsMu.Unlock()
+
+	c.Header("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprintf(c.Writer, `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>Admin · Appeals · gitGost</title>
+<style>body{font-family:Inter,system-ui,sans-serif;background:#0d1117;color:#c9d1d9;max-width:800px;margin:0 auto;padding:32px;}
+h1{color:#ffa657;}table{width:100%%;border-collapse:collapse;margin:16px 0;}
+th,td{text-align:left;padding:10px;border-bottom:1px solid rgba(255,255,255,0.08);}
+th{color:#9fb3ff;font-size:13px;text-transform:uppercase;}
+td{font-family:'IBM Plex Mono',monospace;font-size:13px;}
+.tag{padding:4px 8px;border-radius:6px;font-size:11px;font-weight:600;}
+.tag-open{background:rgba(46,160,67,0.2);color:#3fb950;border:1px solid rgba(46,160,67,0.4);}
+.tag-closed{background:rgba(248,81,73,0.2);color:#f85149;border:1px solid rgba(248,81,73,0.4);}
+a{color:#58a6ff;}.empty{color:#8b949e;}.sep{margin:32px 0;border-color:rgba(255,255,255,0.05);}
+form{display:inline;}
+button{background:transparent;border:1px solid rgba(255,255,255,0.15);color:#c9d1d9;border-radius:6px;padding:4px 10px;cursor:pointer;font-size:12px;}
+button.unban{border-color:#3fb950;color:#3fb950;}
+button.dismiss{border-color:#f85149;color:#f85149;}
+</style></head><body>
+<h1>Appeals</h1>
+<p style="color:#9fb3ff;">Password-protected admin panel. All data is ephemeral (in-memory).</p>
+<hr class="sep">
+<h2>Open (%d)</h2>
+<table><tr><th>Ticket</th><th>Hash</th><th>Message</th><th>Age</th><th>Actions</th></tr>`, len(openList))
+	if len(openList) == 0 {
+		fmt.Fprintf(c.Writer, `<tr><td colspan="5" class="empty">No open appeals.</td></tr>`)
+	}
+	for _, v := range openList {
+		msgPreview := v.Message
+		if len(msgPreview) > 60 {
+			msgPreview = msgPreview[:60] + "..."
+		}
+		age := time.Since(v.CreatedAt).Round(time.Minute)
+		fmt.Fprintf(c.Writer, `<tr><td><a href="/appeal/%s">%s</a></td><td>%s</td><td>%s</td><td>%s</td>
+<td>
+<form method="POST" action="/admin/appeals/%s/resolve" style="display:inline;">
+<input type="hidden" name="password" value="%s">
+<input type="hidden" name="outcome" value="unban">
+<button type="submit" class="unban">Unban</button>
+</form>
+<form method="POST" action="/admin/appeals/%s/resolve" style="display:inline;">
+<input type="hidden" name="password" value="%s">
+<input type="hidden" name="outcome" value="dismiss">
+<button type="submit" class="dismiss">Dismiss</button>
+</form>
+</td></tr>`, v.TicketID, v.TicketID[:8], v.Hash, msgPreview, age, v.TicketID, password, v.TicketID, password)
+	}
+	fmt.Fprintf(c.Writer, `</table>
+<hr class="sep"><h2>Resolved (%d)</h2><table><tr><th>Ticket</th><th>Hash</th><th>Outcome</th></tr>`, len(resolvedList))
+	if len(resolvedList) == 0 {
+		fmt.Fprintf(c.Writer, `<tr><td colspan="3" class="empty">No resolved appeals.</td></tr>`)
+	}
+	for _, v := range resolvedList {
+		outcome := `<span class="tag tag-closed">dismissed</span>`
+		if v.Unbanned {
+			outcome = `<span class="tag tag-open">unbanned</span>`
+		}
+		fmt.Fprintf(c.Writer, `<tr><td>%s</td><td>%s</td><td>%s</td></tr>`, v.TicketID[:8], v.Hash, outcome)
+	}
+	fmt.Fprintf(c.Writer, `</table></body></html>`)
+}
+
+// AdminAppealResolveHandler resuelve una apelacion (unban o dismiss).
+func AdminAppealResolveHandler(c *gin.Context) {
+	ticketID := c.Param("ticket")
+	password := c.PostForm("password")
+	outcome := c.PostForm("outcome")
+
+	if password == "" || panicPassword == "" || password != panicPassword {
+		c.String(http.StatusUnauthorized, "Unauthorized")
+		return
+	}
+
+	appealTicketsMu.Lock()
+	ticket, exists := appealTickets[ticketID]
+	if !exists {
+		appealTicketsMu.Unlock()
+		c.String(http.StatusNotFound, "Appeal not found")
+		return
+	}
+
+	ticket.Resolved = true
+	if outcome == "unban" {
+		ticket.Unbanned = true
+		// Remove from blocked hashes
+		delete(blockedHashes, ticket.Hash)
+		utils.Log("Appeal %s: hash %s unbanned", ticketID[:8], ticket.Hash)
+	} else {
+		ticket.Unbanned = false
+		utils.Log("Appeal %s: hash %s ban upheld", ticketID[:8], ticket.Hash)
+	}
+	appealTicketsMu.Unlock()
+
+	// Send ntfy notification about resolution
+	if ntfyAdminTopic != "" && ticket.Message != "" {
+		go func() {
+			status := "upheld"
+			if outcome == "unban" {
+				status = "unbanned"
+			}
+			payload := fmt.Sprintf(`{"topic":"%s","title":"Appeal %s","message":"Hash %s appeal %s.","tags":["white_check_mark"]}`, ntfyAdminTopic, status, ticket.Hash, status)
+			resp, err := http.Post("https://ntfy.sh", "application/json", strings.NewReader(payload))
+			if err == nil {
+				resp.Body.Close()
+			}
+		}()
+	}
+
+	c.Redirect(http.StatusSeeOther, fmt.Sprintf("/admin/appeals?password=%s", password))
+}

--- a/internal/http/appeal.go
+++ b/internal/http/appeal.go
@@ -400,7 +400,7 @@ button.dismiss{border-color:#f85149;color:#f85149;}
 		if v.Unbanned {
 			outcome = `<span class="tag tag-open">unbanned</span>`
 		}
-		fmt.Fprintf(c.Writer, `<tr><td>%s</td><td>%s</td><td>%s</td></tr>`, v.TicketID[:8], v.Hash, outcome)
+		fmt.Fprintf(c.Writer, `<tr><td>%s</td><td>%s</td><td>%s</td></tr>`, v.TicketID[:8], template.HTMLEscapeString(v.Hash), outcome)
 	}
 	fmt.Fprintf(c.Writer, `</table></body></html>`)
 }

--- a/internal/http/appeal.go
+++ b/internal/http/appeal.go
@@ -388,7 +388,7 @@ button.dismiss{border-color:#f85149;color:#f85149;}
 <input type="hidden" name="outcome" value="dismiss">
 <button type="submit" class="dismiss">Dismiss</button>
 </form>
-</td></tr>`, v.TicketID, v.TicketID[:8], v.Hash, msgPreview, age, v.TicketID, escapedPassword, v.TicketID, escapedPassword)
+</td></tr>`, v.TicketID, v.TicketID[:8], template.HTMLEscapeString(v.Hash), msgPreview, age, v.TicketID, escapedPassword, v.TicketID, escapedPassword)
 	}
 	fmt.Fprintf(c.Writer, `</table>
 <hr class="sep"><h2>Resolved (%d)</h2><table><tr><th>Ticket</th><th>Hash</th><th>Outcome</th></tr>`, len(resolvedList))

--- a/internal/http/appeal.go
+++ b/internal/http/appeal.go
@@ -485,6 +485,6 @@ func AdminAppealResolveHandler(c *gin.Context) {
 		}()
 	}
 
-	c.SetCookie("admin_pass", password, 3600, "/admin/", "", false, true)
+	c.SetCookie("admin_pass", password, 3600, "/admin/", "", true, true)
 	c.Redirect(http.StatusSeeOther, "/admin/appeals")
 }

--- a/internal/http/appeal.go
+++ b/internal/http/appeal.go
@@ -317,6 +317,7 @@ func AdminAppealsHandler(c *gin.Context) {
 		c.String(http.StatusUnauthorized, "Unauthorized")
 		return
 	}
+	escapedPassword := template.HTMLEscapeString(password)
 
 	appealTicketsMu.Lock()
 	type appealView struct {
@@ -387,7 +388,7 @@ button.dismiss{border-color:#f85149;color:#f85149;}
 <input type="hidden" name="outcome" value="dismiss">
 <button type="submit" class="dismiss">Dismiss</button>
 </form>
-</td></tr>`, v.TicketID, v.TicketID[:8], v.Hash, msgPreview, age, v.TicketID, password, v.TicketID, password)
+</td></tr>`, v.TicketID, v.TicketID[:8], v.Hash, msgPreview, age, v.TicketID, escapedPassword, v.TicketID, escapedPassword)
 	}
 	fmt.Fprintf(c.Writer, `</table>
 <hr class="sep"><h2>Resolved (%d)</h2><table><tr><th>Ticket</th><th>Hash</th><th>Outcome</th></tr>`, len(resolvedList))

--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -388,6 +388,7 @@ func ReceivePackHandler(c *gin.Context) {
 	go func() {
 		ntfyTopic := github.NtfyTopicForPR(outPRHash)
 		var ntfyTitle, ntfyMsg string
+		actionBtn := fmt.Sprintf("http, Check Status, %s/api/pr/%s/status, clear=true", github.NtfyServiceURL(), outPRHash)
 		if isUpdate {
 			ntfyTitle = "PR Updated · gitGost"
 			ntfyMsg = fmt.Sprintf("Your anonymous PR was updated.\nPR: %s\nTopic: %s/%s", prURL, github.NtfyBaseURL(), ntfyTopic)
@@ -395,10 +396,17 @@ func ReceivePackHandler(c *gin.Context) {
 			ntfyTitle = "PR Created · gitGost"
 			ntfyMsg = fmt.Sprintf("Your anonymous PR was created.\nPR: %s\nTopic: %s/%s", prURL, github.NtfyBaseURL(), ntfyTopic)
 		}
-		if err := github.PublishNtfyEvent(outPRHash, ntfyTitle, ntfyMsg); err != nil {
+		if err := github.PublishNtfyEvent(outPRHash, ntfyTitle, ntfyMsg, actionBtn); err != nil {
 			utils.Log("ntfy publish error for hash %s: %v", outPRHash, err)
 		}
 	}()
+
+	// Track PR for on-demand status checking
+	if prURL != "" {
+		if num := github.ExtractPRNumber(prURL); num > 0 {
+			trackPR(outPRHash, owner, repo, num, prURL)
+		}
+	}
 
 	// CLEAR SUCCESS MESSAGES
 	WriteSidebandLine(&response, 2, "remote: ")
@@ -647,6 +655,42 @@ const (
 )
 
 var reportPolicyHTML = template.HTML(`<li><strong>0–2 reports:</strong> internal log only.</li><li><strong>3–5 reports:</strong> hash flagged, 6h cooldown, karma reset.</li><li><strong>6+ reports:</strong> hash blocked; we attempt to remove its comments.</li>`)
+
+// PR tracking store for on-demand status checking via /api/pr/:hash/status
+type prTrack struct {
+	Owner    string
+	Repo     string
+	Number   int
+	PRURL    string
+	LastETag string
+	AddedAt  time.Time
+}
+
+var (
+	prTrackMu    sync.RWMutex
+	prTrackStore = make(map[string]*prTrack)
+)
+
+// trackPR almacena metadatos de un PR para consultas de estado posteriores.
+func trackPR(prHash, owner, repo string, number int, prURL string) {
+	prTrackMu.Lock()
+	defer prTrackMu.Unlock()
+	prTrackStore[prHash] = &prTrack{
+		Owner:   owner,
+		Repo:    repo,
+		Number:  number,
+		PRURL:   prURL,
+		AddedAt: time.Now(),
+	}
+}
+
+// getPRTrack obtiene los metadatos de un PR por su hash.
+func getPRTrack(prHash string) (*prTrack, bool) {
+	prTrackMu.RLock()
+	defer prTrackMu.RUnlock()
+	t, ok := prTrackStore[prHash]
+	return t, ok
+}
 
 // newActionToken generates a single-use token valid for actionTokenTTL and stores it.
 func newActionToken() string {
@@ -1067,6 +1111,7 @@ func CreateAnonymousIssueHandler(c *gin.Context) {
 		"karma":             karma,
 		"user_token":        userToken,
 		"issue_reply_token": userToken,
+		"appeal_token":      generateAppealToken(hash),
 	}
 
 	c.JSON(http.StatusOK, resp)
@@ -1142,10 +1187,11 @@ func CreateAnonymousCommentHandler(c *gin.Context) {
 	}
 
 	resp := gin.H{
-		"comment_url": commentURL,
-		"hash":        hash,
-		"karma":       karma,
-		"user_token":  userToken,
+		"comment_url":  commentURL,
+		"hash":         hash,
+		"karma":        karma,
+		"user_token":   userToken,
+		"appeal_token": generateAppealToken(hash),
 	}
 
 	c.JSON(http.StatusOK, resp)
@@ -1221,10 +1267,11 @@ func CreateAnonymousPRCommentHandler(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"comment_url": commentURL,
-		"hash":        hash,
-		"karma":       karma,
-		"user_token":  userToken,
+		"comment_url":  commentURL,
+		"hash":         hash,
+		"karma":        karma,
+		"user_token":   userToken,
+		"appeal_token": generateAppealToken(hash),
 	})
 }
 
@@ -1736,6 +1783,84 @@ func PRStatusHandler(c *gin.Context) {
 		"ntfy_topic":    topic,
 		"subscribe_url": subscribeURL,
 	})
+}
+
+// PRCheckHandler devuelve el estado actual de un PR consultando la API de GitHub.
+// Solo funciona para PRs creados a traves de gitGost (trackeados en memoria).
+// Usa ETag para cache eficiente: en cada respuesta devuelve el ETag actual.
+// El cliente puede enviarlo en el header If-None-Match en consultas posteriores.
+func PRCheckHandler(c *gin.Context) {
+	hash := strings.TrimSpace(c.Param("hash"))
+	if hash == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "hash is required"})
+		return
+	}
+
+	track, ok := getPRTrack(hash)
+	if !ok {
+		c.JSON(http.StatusNotFound, gin.H{
+			"hash":    hash,
+			"tracked": false,
+			"error":   "PR not found. This endpoint only tracks PRs created through gitGost.",
+		})
+		return
+	}
+
+	// Obtener informacion basica del PR (state, title, comments)
+	state, title, comments, updatedAt, err := github.FetchPRInfo(track.Owner, track.Repo, track.Number)
+	if err != nil {
+		utils.Log("Error fetching PR info for %s/%s#%d: %v", track.Owner, track.Repo, track.Number, err)
+		c.JSON(http.StatusOK, gin.H{
+			"hash":      hash,
+			"tracked":   true,
+			"pr_number": track.Number,
+			"owner":     track.Owner,
+			"repo":      track.Repo,
+			"pr_url":    track.PRURL,
+			"error":     "could not fetch PR info from GitHub",
+		})
+		return
+	}
+
+	// Obtener timeline con ETag
+	events, newETag, changed, err := github.FetchPRTimeline(track.Owner, track.Repo, track.Number, track.LastETag)
+	if err != nil {
+		utils.Log("Error fetching PR timeline for %s/%s#%d: %v", track.Owner, track.Repo, track.Number, err)
+		// Devolvemos la info basica aunque falle el timeline
+	}
+
+	// Actualizar ETag si hubo cambios o si es la primera vez
+	if changed || track.LastETag == "" {
+		prTrackMu.Lock()
+		if track, ok := prTrackStore[hash]; ok {
+			track.LastETag = newETag
+		}
+		prTrackMu.Unlock()
+	}
+
+	response := gin.H{
+		"hash":       hash,
+		"tracked":    true,
+		"pr_number":  track.Number,
+		"owner":      track.Owner,
+		"repo":       track.Repo,
+		"pr_url":     track.PRURL,
+		"state":      state,
+		"title":      title,
+		"comments":   comments,
+		"updated_at": updatedAt,
+		"new_events": changed,
+	}
+
+	if events != nil {
+		// Devolver solo los ultimos 10 eventos para no saturar
+		if len(events) > 10 {
+			events = events[len(events)-10:]
+		}
+		response["events"] = events
+	}
+
+	c.JSON(http.StatusOK, response)
 }
 
 // VerifyHandler sirve instrucciones de verificación matemática del binario desplegado.

--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -669,6 +669,7 @@ type prTrack struct {
 var (
 	prTrackMu    sync.RWMutex
 	prTrackStore = make(map[string]*prTrack)
+	prTrackTTL   = 24 * time.Hour
 )
 
 // trackPR almacena metadatos de un PR para consultas de estado posteriores.
@@ -684,12 +685,22 @@ func trackPR(prHash, owner, repo string, number int, prURL string) {
 	}
 }
 
-// getPRTrack obtiene los metadatos de un PR por su hash.
-func getPRTrack(prHash string) (*prTrack, bool) {
-	prTrackMu.RLock()
-	defer prTrackMu.RUnlock()
+// getPRTrack obtiene una copia de los metadatos de un PR por su hash.
+// Retorna una copia (value) obtenida bajo el lock, incluyendo LastETag,
+// para que el llamador pueda usarla sin condiciones de carrera.
+// Elimina entradas expiradas para evitar acumulacion de stale data.
+func getPRTrack(prHash string) (prTrack, bool) {
+	prTrackMu.Lock()
+	defer prTrackMu.Unlock()
 	t, ok := prTrackStore[prHash]
-	return t, ok
+	if !ok {
+		return prTrack{}, false
+	}
+	if time.Since(t.AddedAt) > prTrackTTL {
+		delete(prTrackStore, prHash)
+		return prTrack{}, false
+	}
+	return *t, true
 }
 
 // newActionToken generates a single-use token valid for actionTokenTTL and stores it.

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -11,6 +11,27 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// securityHeaders agrega cabeceras de seguridad a todas las respuestas.
+func securityHeaders() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Header("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+		c.Header("X-Frame-Options", "DENY")
+		c.Header("X-Content-Type-Options", "nosniff")
+		c.Header("Referrer-Policy", "strict-origin-when-cross-origin")
+		c.Header("Content-Security-Policy",
+			"default-src 'self'; "+
+				"script-src 'self' https://cdn.jsdelivr.net https://unpkg.com 'unsafe-inline'; "+
+				"style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; "+
+				"font-src 'self' https://fonts.gstatic.com; "+
+				"img-src 'self' data:; "+
+				"object-src 'none'; "+
+				"frame-ancestors 'none'; "+
+				"connect-src 'self'",
+		)
+		c.Next()
+	}
+}
+
 // adminLimiterState holds per-IP sliding-window counters for admin endpoints.
 var (
 	adminLimiterMu    sync.Mutex
@@ -136,6 +157,9 @@ func SetupRouter(cfg *config.Config) *gin.Engine {
 	// Solo recovery, sin logger para proteger anonimato
 	r.Use(gin.Recovery())
 
+	// Cabeceras de seguridad en todas las respuestas
+	r.Use(securityHeaders())
+
 	// Health y metrics (no auth)
 	r.GET("/health", HealthHandler)
 	r.GET("/metrics", MetricsHandler)
@@ -152,6 +176,9 @@ func SetupRouter(cfg *config.Config) *gin.Engine {
 	r.StaticFile("/approach.html", "./web/approach.html")
 	r.StaticFile("/guidelines.html", "./web/guidelines.html")
 	r.StaticFile("/karma.html", "./web/karma.html")
+
+	// Security policy (security.txt)
+	r.StaticFile("/.well-known/security.txt", "./web/.well-known/security.txt")
 
 	// Static assets
 	r.Static("/assets", "./web/assets")
@@ -214,7 +241,14 @@ func SetupRouter(cfg *config.Config) *gin.Engine {
 		api.GET("/stats", StatsHandler)
 		api.GET("/recent-prs", RecentPRsHandler)
 		api.GET("/pr-status/:hash", PRStatusHandler)
+		api.GET("/pr/:hash/status", PRCheckHandler)
 	}
+
+	// Appeal routes — anonymous appeal system
+	r.GET("/appeal", AppealStartHandler)
+	r.POST("/appeal", AppealStartHandler)
+	r.GET("/appeal/:ticket", AppealViewHandler)
+	r.POST("/appeal/:ticket", AppealViewHandler)
 
 	// Admin endpoints — protected by strict per-IP rate limiting
 	admin := r.Group("/admin")
@@ -222,6 +256,8 @@ func SetupRouter(cfg *config.Config) *gin.Engine {
 	{
 		admin.POST("/panic", PanicHandler)
 		admin.POST("/rollback", RollbackBurstHandler)
+		admin.GET("/appeals", AdminAppealsHandler)
+		admin.POST("/appeals/:ticket/resolve", AdminAppealResolveHandler)
 	}
 
 	// Service status (para el frontend)

--- a/web/.well-known/security.txt
+++ b/web/.well-known/security.txt
@@ -1,0 +1,4 @@
+Contact: mailto:gitGost@proton.me
+Canonical: https://gitgost.fly.dev/.well-known/security.txt
+Expires: 2027-01-01T00:00:00Z
+Preferred-Languages: en


### PR DESCRIPTION
Implement an ephemeral in-memory appeal system allowing users to appeal blocked hashes using deterministic HMAC tokens. Add PR status tracking and on-demand checking via new /api/pr/:hash/status endpoint. Enhance ntfy notifications with action buttons for immediate PR status checks. Add security headers and security.txt policy file. Include new GitHub API functions for fetching PR timeline and metadata with ETag caching.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an on-demand pull request status endpoint used by notification action links.
  * Enhanced notifications with an actionable “Check Status” button.
  * Introduced an anonymous appeal flow for blocked hashes with private ticket handling and tracking.
  * Added an admin appeals dashboard to review, resolve, and manage outcomes.
* **Security**
  * Added stronger default HTTP security headers.
  * Published `/.well-known/security.txt` with contact and policy details.
* **Bug Fixes**
  * Improved pull request change detection and metadata freshness using ETag-based timeline checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->