### PR TITLE
Add PR/MR status tracking and on-demand check endpoint

### DIFF
--- a/internal/github/ntfy.go
+++ b/internal/github/ntfy.go
@@ -33,7 +33,9 @@ func NtfyServiceURL() string {
 }
 
 // PublishNtfyEvent publishes an event to the ntfy topic corresponding to a PR hash.
-func PublishNtfyEvent(prHash, title, message string) error {
+// actions: optional ntfy Actions header value (e.g. a button to check PR status).
+// Pass empty string to send without action buttons.
+func PublishNtfyEvent(prHash, title, message, actions string) error {
 	topic := NtfyTopicForPR(prHash)
 	url := fmt.Sprintf("%s/%s", NtfyBaseURL(), topic)
 
@@ -44,6 +46,9 @@ func PublishNtfyEvent(prHash, title, message string) error {
 	req.Header.Set("Title", title)
 	req.Header.Set("Tags", "bell")
 	req.Header.Set("Content-Type", "text/plain; charset=utf-8")
+	if actions != "" {
+		req.Header.Set("Actions", actions)
+	}
 
 	resp, err := ntfyClient.Do(req)
 	if err != nil {

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -789,4 +790,120 @@ func GetExistingPR(owner, repo, forkOwner, branchName string) (string, bool, err
 	}
 
 	return prs[0].HTMLURL, true, nil
+}
+
+// PRTimelineEvent representa un evento individual del timeline de un PR.
+type PRTimelineEvent struct {
+	Event     string `json:"event"`
+	CreatedAt string `json:"created_at"`
+	Body      string `json:"body,omitempty"`
+	User      *struct {
+		Login string `json:"login"`
+	} `json:"user,omitempty"`
+	State string `json:"state,omitempty"`
+	Label *struct {
+		Name string `json:"name"`
+	} `json:"label,omitempty"`
+}
+
+// ExtractPRNumber extrae el numero de PR de una URL de GitHub.
+func ExtractPRNumber(prURL string) int {
+	parts := strings.Split(strings.TrimPrefix(prURL, "https://github.com/"), "/")
+	if len(parts) < 4 || parts[2] != "pull" {
+		return 0
+	}
+	n, err := strconv.Atoi(parts[3])
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+// FetchPRTimeline obtiene el timeline de un PR desde la API de GitHub con ETag.
+func FetchPRTimeline(owner, repo string, number int, etag string) (events []PRTimelineEvent, newETag string, changed bool, err error) {
+	token := os.Getenv("GITHUB_TOKEN")
+	if token == "" {
+		return nil, "", false, fmt.Errorf("GITHUB_TOKEN not set")
+	}
+
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/issues/%d/timeline?per_page=100", owner, repo, number)
+
+	req, err := http.NewRequest("GET", apiURL, nil)
+	if err != nil {
+		return nil, "", false, err
+	}
+	req.Header.Set("Authorization", "token "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "gitGost")
+	if etag != "" {
+		req.Header.Set("If-None-Match", etag)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, "", false, err
+	}
+	defer resp.Body.Close()
+
+	newETag = resp.Header.Get("ETag")
+
+	if resp.StatusCode == http.StatusNotModified {
+		return nil, newETag, false, nil
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", false, fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&events); err != nil {
+		return nil, "", false, err
+	}
+
+	if events == nil {
+		events = []PRTimelineEvent{}
+	}
+
+	return events, newETag, true, nil
+}
+
+// FetchPRInfo obtiene informacion basica del PR (state, title, comments).
+func FetchPRInfo(owner, repo string, number int) (state, title string, comments int, updatedAt string, err error) {
+	token := os.Getenv("GITHUB_TOKEN")
+	if token == "" {
+		return "", "", 0, "", fmt.Errorf("GITHUB_TOKEN not set")
+	}
+
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/issues/%d", owner, repo, number)
+
+	req, err := http.NewRequest("GET", apiURL, nil)
+	if err != nil {
+		return "", "", 0, "", err
+	}
+	req.Header.Set("Authorization", "token "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "gitGost")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", "", 0, "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", "", 0, "", fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
+	}
+
+	var result struct {
+		State       string    `json:"state"`
+		Title       string    `json:"title"`
+		Comments    int       `json:"comments"`
+		UpdatedAt   string    `json:"updated_at"`
+		PullRequest *struct{} `json:"pull_request,omitempty"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", "", 0, "", err
+	}
+
+	return result.State, result.Title, result.Comments, result.UpdatedAt, nil
 }

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -754,8 +754,27 @@ func ExtractPRNumber(prURL string) int {
 	return n
 }
 
+// nextPageURL extrae la URL de la pagina siguiente del header Link de GitHub.
+func nextPageURL(linkHeader string) string {
+	if linkHeader == "" {
+		return ""
+	}
+	for _, part := range strings.Split(linkHeader, ",") {
+		part = strings.TrimSpace(part)
+		if strings.Contains(part, `rel="next"`) {
+			start := strings.Index(part, "<")
+			end := strings.Index(part, ">")
+			if start != -1 && end != -1 {
+				return part[start+1 : end]
+			}
+		}
+	}
+	return ""
+}
+
 // FetchPRTimeline obtiene el timeline de un PR desde la API de GitHub.
 // Usa ETag/If-None-Match para evitar datos innecesarios.
+// Recorre todas las paginas via Link header.
 // Retorna los eventos, el nuevo ETag, si hubo cambios, o error.
 func FetchPRTimeline(owner, repo string, number int, etag string) (events []PRTimelineEvent, newETag string, changed bool, err error) {
 	token := os.Getenv("GITHUB_TOKEN")
@@ -765,35 +784,51 @@ func FetchPRTimeline(owner, repo string, number int, etag string) (events []PRTi
 
 	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/issues/%d/timeline?per_page=100", owner, repo, number)
 
-	req, err := http.NewRequest("GET", apiURL, nil)
-	if err != nil {
-		return nil, "", false, err
-	}
-	req.Header.Set("Authorization", "token "+token)
-	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("User-Agent", "gitGost")
-	if etag != "" {
-		req.Header.Set("If-None-Match", etag)
-	}
+	for apiURL != "" {
+		req, err := http.NewRequest("GET", apiURL, nil)
+		if err != nil {
+			return nil, "", false, err
+		}
+		req.Header.Set("Authorization", "token "+token)
+		req.Header.Set("Accept", "application/vnd.github+json")
+		req.Header.Set("User-Agent", "gitGost")
+		// Solo enviar ETag en la primera peticion (caching global)
+		if etag != "" && newETag == "" {
+			req.Header.Set("If-None-Match", etag)
+		}
 
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, "", false, err
-	}
-	defer resp.Body.Close()
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			return nil, "", false, err
+		}
 
-	newETag = resp.Header.Get("ETag")
+		// Conservar el ETag de la primera respuesta
+		if newETag == "" {
+			newETag = resp.Header.Get("ETag")
+		}
 
-	if resp.StatusCode == http.StatusNotModified {
-		return nil, newETag, false, nil
-	}
+		if resp.StatusCode == http.StatusNotModified {
+			resp.Body.Close()
+			return nil, newETag, false, nil
+		}
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, "", false, fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
-	}
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			return nil, "", false, fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
+		}
 
-	if err := json.NewDecoder(resp.Body).Decode(&events); err != nil {
-		return nil, "", false, err
+		var page []PRTimelineEvent
+		if err := json.NewDecoder(resp.Body).Decode(&page); err != nil {
+			resp.Body.Close()
+			return nil, "", false, err
+		}
+		resp.Body.Close()
+
+		if page != nil {
+			events = append(events, page...)
+		}
+
+		apiURL = nextPageURL(resp.Header.Get("Link"))
 	}
 
 	// GitHub puede devolver null en lugar de array
@@ -805,14 +840,15 @@ func FetchPRTimeline(owner, repo string, number int, etag string) (events []PRTi
 }
 
 // FetchPRInfo obtiene informacion basica del PR (state, title, comments count).
-// Usa el endpoint de issues ya que los PRs son issues.
+// Usa el endpoint de pulls para obtener datos especificos de PR
+// (review_comments para el conteo de discusion, merged_at para estado merged).
 func FetchPRInfo(owner, repo string, number int) (state, title string, comments int, updatedAt string, err error) {
 	token := os.Getenv("GITHUB_TOKEN")
 	if token == "" {
 		return "", "", 0, "", fmt.Errorf("GITHUB_TOKEN not set")
 	}
 
-	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/issues/%d", owner, repo, number)
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/pulls/%d", owner, repo, number)
 
 	req, err := http.NewRequest("GET", apiURL, nil)
 	if err != nil {
@@ -833,19 +869,23 @@ func FetchPRInfo(owner, repo string, number int) (state, title string, comments 
 	}
 
 	var result struct {
-		State     string `json:"state"`
-		Title     string `json:"title"`
-		Comments  int    `json:"comments"`
-		UpdatedAt string `json:"updated_at"`
-		// El campo pull_request existe solo si es un PR
-		PullRequest *struct{} `json:"pull_request,omitempty"`
+		State          string  `json:"state"`
+		Title          string  `json:"title"`
+		ReviewComments int     `json:"review_comments"`
+		UpdatedAt      string  `json:"updated_at"`
+		MergedAt       *string `json:"merged_at"`
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return "", "", 0, "", err
 	}
 
-	return result.State, result.Title, result.Comments, result.UpdatedAt, nil
+	state = result.State
+	if result.MergedAt != nil {
+		state = "merged"
+	}
+
+	return state, result.Title, result.ReviewComments, result.UpdatedAt, nil
 }
 
 // GetExistingPR busca si existe un PR abierto desde forkOwner:branchName hacia owner/repo.
@@ -913,120 +953,4 @@ func GetExistingPR(owner, repo, forkOwner, branchName string) (string, bool, err
 	}
 
 	return prs[0].HTMLURL, true, nil
-}
-
-// PRTimelineEvent representa un evento individual del timeline de un PR.
-type PRTimelineEvent struct {
-	Event     string `json:"event"`
-	CreatedAt string `json:"created_at"`
-	Body      string `json:"body,omitempty"`
-	User      *struct {
-		Login string `json:"login"`
-	} `json:"user,omitempty"`
-	State string `json:"state,omitempty"`
-	Label *struct {
-		Name string `json:"name"`
-	} `json:"label,omitempty"`
-}
-
-// ExtractPRNumber extrae el numero de PR de una URL de GitHub.
-func ExtractPRNumber(prURL string) int {
-	parts := strings.Split(strings.TrimPrefix(prURL, "https://github.com/"), "/")
-	if len(parts) < 4 || parts[2] != "pull" {
-		return 0
-	}
-	n, err := strconv.Atoi(parts[3])
-	if err != nil {
-		return 0
-	}
-	return n
-}
-
-// FetchPRTimeline obtiene el timeline de un PR desde la API de GitHub con ETag.
-func FetchPRTimeline(owner, repo string, number int, etag string) (events []PRTimelineEvent, newETag string, changed bool, err error) {
-	token := os.Getenv("GITHUB_TOKEN")
-	if token == "" {
-		return nil, "", false, fmt.Errorf("GITHUB_TOKEN not set")
-	}
-
-	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/issues/%d/timeline?per_page=100", owner, repo, number)
-
-	req, err := http.NewRequest("GET", apiURL, nil)
-	if err != nil {
-		return nil, "", false, err
-	}
-	req.Header.Set("Authorization", "token "+token)
-	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("User-Agent", "gitGost")
-	if etag != "" {
-		req.Header.Set("If-None-Match", etag)
-	}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, "", false, err
-	}
-	defer resp.Body.Close()
-
-	newETag = resp.Header.Get("ETag")
-
-	if resp.StatusCode == http.StatusNotModified {
-		return nil, newETag, false, nil
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, "", false, fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
-	}
-
-	if err := json.NewDecoder(resp.Body).Decode(&events); err != nil {
-		return nil, "", false, err
-	}
-
-	if events == nil {
-		events = []PRTimelineEvent{}
-	}
-
-	return events, newETag, true, nil
-}
-
-// FetchPRInfo obtiene informacion basica del PR (state, title, comments).
-func FetchPRInfo(owner, repo string, number int) (state, title string, comments int, updatedAt string, err error) {
-	token := os.Getenv("GITHUB_TOKEN")
-	if token == "" {
-		return "", "", 0, "", fmt.Errorf("GITHUB_TOKEN not set")
-	}
-
-	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/issues/%d", owner, repo, number)
-
-	req, err := http.NewRequest("GET", apiURL, nil)
-	if err != nil {
-		return "", "", 0, "", err
-	}
-	req.Header.Set("Authorization", "token "+token)
-	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("User-Agent", "gitGost")
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return "", "", 0, "", err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", "", 0, "", fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
-	}
-
-	var result struct {
-		State       string    `json:"state"`
-		Title       string    `json:"title"`
-		Comments    int       `json:"comments"`
-		UpdatedAt   string    `json:"updated_at"`
-		PullRequest *struct{} `json:"pull_request,omitempty"`
-	}
-
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return "", "", 0, "", err
-	}
-
-	return result.State, result.Title, result.Comments, result.UpdatedAt, nil
 }

--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -388,6 +388,7 @@ func ReceivePackHandler(c *gin.Context) {
 	go func() {
 		ntfyTopic := github.NtfyTopicForPR(outPRHash)
 		var ntfyTitle, ntfyMsg string
+		actionStatus := fmt.Sprintf("http, Check Status, %s/api/pr/%s/status, clear=true", github.NtfyServiceURL(), outPRHash)
 		if isUpdate {
 			ntfyTitle = "PR Updated · gitGost"
 			ntfyMsg = fmt.Sprintf("Your anonymous PR was updated.\nPR: %s\nTopic: %s/%s", prURL, github.NtfyBaseURL(), ntfyTopic)
@@ -395,10 +396,21 @@ func ReceivePackHandler(c *gin.Context) {
 			ntfyTitle = "PR Created · gitGost"
 			ntfyMsg = fmt.Sprintf("Your anonymous PR was created.\nPR: %s\nTopic: %s/%s", prURL, github.NtfyBaseURL(), ntfyTopic)
 		}
-		if err := github.PublishNtfyEvent(outPRHash, ntfyTitle, ntfyMsg); err != nil {
+		if err := github.PublishNtfyEvent(outPRHash, ntfyTitle, ntfyMsg, actionStatus); err != nil {
 			utils.Log("ntfy publish error for hash %s: %v", outPRHash, err)
 		}
 	}()
+
+	// Track PR for on-demand status checking
+	if prURL != "" {
+		provShort := "gh"
+		if strings.HasPrefix(c.Request.URL.Path, "/v1/gl/") {
+			provShort = "gl"
+		}
+		if num := github.ExtractPRNumber(prURL); num > 0 {
+			trackPR(outPRHash, owner, repo, num, prURL, provShort)
+		}
+	}
 
 	// CLEAR SUCCESS MESSAGES
 	WriteSidebandLine(&response, 2, "remote: ")
@@ -647,6 +659,54 @@ const (
 )
 
 var reportPolicyHTML = template.HTML(`<li><strong>0–2 reports:</strong> internal log only.</li><li><strong>3–5 reports:</strong> hash flagged, 6h cooldown, karma reset.</li><li><strong>6+ reports:</strong> hash blocked; we attempt to remove its comments.</li>`)
+
+// PR tracking store for on-demand status checking via /api/pr/:hash/status
+type prTrack struct {
+	Owner    string
+	Repo     string
+	Number   int
+	PRURL    string
+	Provider string // "gh" o "gl"
+	LastETag string
+	AddedAt  time.Time
+}
+
+var (
+	prTrackMu    sync.RWMutex
+	prTrackStore = make(map[string]*prTrack)
+)
+
+// trackPR almacena metadatos de un PR para consultas de estado posteriores.
+func trackPR(prHash, owner, repo string, number int, prURL, provider string) {
+	prTrackMu.Lock()
+	defer prTrackMu.Unlock()
+	prTrackStore[prHash] = &prTrack{
+		Owner:    owner,
+		Repo:     repo,
+		Number:   number,
+		PRURL:    prURL,
+		Provider: provider,
+		AddedAt:  time.Now(),
+	}
+}
+
+// getPRTrack obtiene los metadatos de un PR por su hash.
+func getPRTrack(prHash string) (*prTrack, bool) {
+	prTrackMu.RLock()
+	defer prTrackMu.RUnlock()
+	t, ok := prTrackStore[prHash]
+	return t, ok
+}
+
+// providerFromName devuelve el provider adecuado segun el nombre corto.
+func providerFromName(name string) provider.Provider {
+	switch name {
+	case "gl":
+		return glprovider.New()
+	default:
+		return ghprovider.New()
+	}
+}
 
 // newActionToken generates a single-use token valid for actionTokenTTL and stores it.
 func newActionToken() string {
@@ -1738,7 +1798,64 @@ func PRStatusHandler(c *gin.Context) {
 	})
 }
 
-// VerifyHandler sirve instrucciones de verificación matemática del binario desplegado.
+// PRCheckHandler devuelve el estado actual de un PR/MR consultando la API del proveedor.
+// Solo funciona para PRs creados a traves de gitGost (trackeados en memoria).
+func PRCheckHandler(c *gin.Context) {
+	hash := strings.TrimSpace(c.Param("hash"))
+	if hash == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "hash is required"})
+		return
+	}
+
+	track, ok := getPRTrack(hash)
+	if !ok {
+		c.JSON(http.StatusNotFound, gin.H{
+			"hash":    hash,
+			"tracked": false,
+			"error":   "PR not found. This endpoint only tracks PRs created through gitGost.",
+		})
+		return
+	}
+
+	prov := providerFromName(track.Provider)
+	status, err := prov.GetMRStatus(track.Owner, track.Repo, track.Number)
+	if err != nil {
+		utils.Log("Error fetching MR status for %s/%s#%d: %v", track.Owner, track.Repo, track.Number, err)
+		c.JSON(http.StatusOK, gin.H{
+			"hash":      hash,
+			"tracked":   true,
+			"pr_number": track.Number,
+			"owner":     track.Owner,
+			"repo":      track.Repo,
+			"pr_url":    track.PRURL,
+			"error":     "could not fetch status from provider",
+		})
+		return
+	}
+
+	// Limitar eventos a los ultimos 10
+	events := status.Events
+	if len(events) > 10 {
+		events = events[len(events)-10:]
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"hash":       hash,
+		"tracked":    true,
+		"pr_number":  status.Number,
+		"owner":      track.Owner,
+		"repo":       track.Repo,
+		"pr_url":     track.PRURL,
+		"provider":   track.Provider,
+		"state":      status.State,
+		"title":      status.Title,
+		"comments":   status.Comments,
+		"updated_at": status.UpdatedAt,
+		"events":     events,
+	})
+}
+
+// VerifyHandler sirve instrucciones de verificacion matematica del binario desplegado.
 // Solo expone commitHash y sourceRepo (datos públicos, sin variables de entorno ni secretos).
 func VerifyHandler(c *gin.Context) {
 	shortHash := commitHash

--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -678,9 +678,9 @@ type prTrack struct {
 }
 
 var (
-	prTrackMu          sync.RWMutex
-	prTrackStore       = make(map[string]*prTrack)
-	prTrackTTL         = 24 * time.Hour
+	prTrackMu           sync.RWMutex
+	prTrackStore        = make(map[string]*prTrack)
+	prTrackTTL          = 24 * time.Hour
 	prTrackEvictionOnce sync.Once
 )
 
@@ -744,7 +744,6 @@ func providerFromName(name string) provider.Provider {
 	default:
 		return ghprovider.New()
 	}
-}
 }
 
 // newActionToken generates a single-use token valid for actionTokenTTL and stores it.
@@ -1911,6 +1910,8 @@ func PRCheckHandler(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, response)
+}
+
 // Solo expone commitHash y sourceRepo (datos públicos, sin variables de entorno ni secretos).
 func VerifyHandler(c *gin.Context) {
 	shortHash := commitHash

--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -388,7 +388,7 @@ func ReceivePackHandler(c *gin.Context) {
 	go func() {
 		ntfyTopic := github.NtfyTopicForPR(outPRHash)
 		var ntfyTitle, ntfyMsg string
-		actionBtn := fmt.Sprintf("http, Check Status, %s/api/pr/%s/status, clear=true", github.NtfyServiceURL(), outPRHash)
+		actionBtn := fmt.Sprintf("http, Check Status, %s/api/pr/%s/status, clear=true, method=GET", github.NtfyServiceURL(), outPRHash)
 		if isUpdate {
 			ntfyTitle = "PR Updated · gitGost"
 			ntfyMsg = fmt.Sprintf("Your anonymous PR was updated.\nPR: %s\nTopic: %s/%s", prURL, github.NtfyBaseURL(), ntfyTopic)
@@ -407,8 +407,14 @@ func ReceivePackHandler(c *gin.Context) {
 		if strings.HasPrefix(c.Request.URL.Path, "/v1/gl/") {
 			provShort = "gl"
 		}
-		if num := github.ExtractPRNumber(prURL); num > 0 {
-			trackPR(outPRHash, owner, repo, num, prURL, provShort)
+		if provShort == "gl" {
+			if num := glprovider.ExtractMRIID(prURL); num > 0 {
+				trackPR(outPRHash, owner, repo, num, prURL, provShort)
+			}
+		} else {
+			if num := github.ExtractPRNumber(prURL); num > 0 {
+				trackPR(outPRHash, owner, repo, num, prURL, provShort)
+			}
 		}
 	}
 
@@ -668,18 +674,38 @@ type prTrack struct {
 	PRURL    string
 	Provider string // "gh" or "gl"
 	LastETag string
-	LastETag string
 	AddedAt  time.Time
 }
 
 var (
-	prTrackMu    sync.RWMutex
-	prTrackStore = make(map[string]*prTrack)
-	prTrackTTL   = 24 * time.Hour
+	prTrackMu          sync.RWMutex
+	prTrackStore       = make(map[string]*prTrack)
+	prTrackTTL         = 24 * time.Hour
+	prTrackEvictionOnce sync.Once
 )
+
+// startPRTrackEviction inicia un goroutine que limpia entradas expiradas cada 10 min.
+func startPRTrackEviction() {
+	prTrackEvictionOnce.Do(func() {
+		go func() {
+			ticker := time.NewTicker(10 * time.Minute)
+			defer ticker.Stop()
+			for range ticker.C {
+				prTrackMu.Lock()
+				for hash, t := range prTrackStore {
+					if time.Since(t.AddedAt) > prTrackTTL {
+						delete(prTrackStore, hash)
+					}
+				}
+				prTrackMu.Unlock()
+			}
+		}()
+	})
+}
 
 // trackPR almacena metadatos de un PR para consultas de estado posteriores.
 func trackPR(prHash, owner, repo string, number int, prURL, provider string) {
+	startPRTrackEviction()
 	prTrackMu.Lock()
 	defer prTrackMu.Unlock()
 	prTrackStore[prHash] = &prTrack{

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -214,6 +214,7 @@ func SetupRouter(cfg *config.Config) *gin.Engine {
 		api.GET("/stats", StatsHandler)
 		api.GET("/recent-prs", RecentPRsHandler)
 		api.GET("/pr-status/:hash", PRStatusHandler)
+		api.GET("/pr/:hash/status", PRCheckHandler)
 	}
 
 	// Admin endpoints — protected by strict per-IP rate limiting

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -66,6 +66,40 @@ func adminLimiter() gin.HandlerFunc {
 	}
 }
 
+// prCheckLimiterState holds per-IP sliding-window counters for PR status endpoint.
+var (
+	prCheckLimiterMu    sync.Mutex
+	prCheckLimiterStore = make(map[string][]time.Time)
+	prCheckLimiterMax   = 30
+	prCheckLimiterWin   = time.Minute
+)
+
+// prCheckLimiter enforces a per-IP rate limit on the PR status check endpoint.
+func prCheckLimiter() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ip := c.ClientIP()
+		now := time.Now()
+		cutoff := now.Add(-prCheckLimiterWin)
+		prCheckLimiterMu.Lock()
+		times := prCheckLimiterStore[ip]
+		valid := times[:0]
+		for _, t := range times {
+			if t.After(cutoff) {
+				valid = append(valid, t)
+			}
+		}
+		valid = append(valid, now)
+		prCheckLimiterStore[ip] = valid
+		exceeded := len(valid) > prCheckLimiterMax
+		prCheckLimiterMu.Unlock()
+		if exceeded {
+			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": "PR check rate limit exceeded"})
+			return
+		}
+		c.Next()
+	}
+}
+
 // maxPushSize is the maximum allowed push size
 const maxPushSize = 100 * 1024 * 1024 // 100MB
 
@@ -241,7 +275,7 @@ func SetupRouter(cfg *config.Config) *gin.Engine {
 		api.GET("/stats", StatsHandler)
 		api.GET("/recent-prs", RecentPRsHandler)
 		api.GET("/pr-status/:hash", PRStatusHandler)
-		api.GET("/pr/:hash/status", PRCheckHandler)
+		api.GET("/pr/:hash/status", prCheckLimiter(), PRCheckHandler)
 	}
 
 	// Appeal routes — anonymous appeal system

--- a/internal/provider/github/github.go
+++ b/internal/provider/github/github.go
@@ -83,3 +83,34 @@ func (p *GitHubProvider) CreateAnonymousComment(owner, repo string, number int, 
 func (p *GitHubProvider) CreateAnonymousPRComment(owner, repo string, number int, body string) (string, error) {
 	return github.CreateAnonymousPRComment(owner, repo, number, body)
 }
+
+func (p *GitHubProvider) GetMRStatus(owner, repo string, number int) (*provider.MRStatus, error) {
+	state, title, comments, updatedAt, err := github.FetchPRInfo(owner, repo, number)
+	if err != nil {
+		return nil, err
+	}
+
+	events, _, _, err := github.FetchPRTimeline(owner, repo, number, "")
+	if err != nil {
+		return &provider.MRStatus{
+			State: state, Title: title, Number: number,
+			Comments: comments, UpdatedAt: updatedAt, Events: []provider.Event{},
+		}, nil
+	}
+
+	providerEvents := make([]provider.Event, len(events))
+	for i, e := range events {
+		author := ""
+		if e.User != nil {
+			author = e.User.Login
+		}
+		providerEvents[i] = provider.Event{
+			Type: e.Event, Author: author, Body: e.Body, CreatedAt: e.CreatedAt,
+		}
+	}
+
+	return &provider.MRStatus{
+		State: state, Title: title, Number: number,
+		Comments: comments, UpdatedAt: updatedAt, Events: providerEvents,
+	}, nil
+}

--- a/internal/provider/gitlab/gitlab.go
+++ b/internal/provider/gitlab/gitlab.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -14,6 +15,21 @@ import (
 )
 
 var httpClient = &http.Client{Timeout: 60 * time.Second}
+
+// ExtractMRIID extrae el IID de un MR de una URL de GitLab.
+// Formato: https://gitlab.com/{owner}/{repo}/-/merge_requests/{iid}
+func ExtractMRIID(mrURL string) int {
+	trimmed := strings.TrimPrefix(mrURL, "https://gitlab.com/")
+	parts := strings.Split(trimmed, "/-/merge_requests/")
+	if len(parts) != 2 {
+		return 0
+	}
+	n, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0
+	}
+	return n
+}
 
 // GitLabProvider implements provider.Provider for GitLab.
 type GitLabProvider struct{}
@@ -488,6 +504,88 @@ func (p *GitLabProvider) CreateAnonymousPRComment(owner, repo string, number int
 		return "", err
 	}
 	return fmt.Sprintf("https://gitlab.com/%s/%s/-/merge_requests/%d#note_%d", owner, repo, number, result.ID), nil
+}
+
+// GetMRStatus obtiene el estado actual de un MR desde GitLab.
+func (p *GitLabProvider) GetMRStatus(owner, repo string, number int) (*provider.MRStatus, error) {
+	t := token()
+	if t == "" {
+		return nil, fmt.Errorf("GITLAB_TOKEN not set")
+	}
+
+	pid := projectID(owner, repo)
+
+	// Obtener info del MR
+	mrURL := fmt.Sprintf("https://gitlab.com/api/v4/projects/%s/merge_requests/%d", pid, number)
+	mrReq, _ := http.NewRequest("GET", mrURL, nil)
+	authHeader(mrReq)
+	mrResp, err := httpClient.Do(mrReq)
+	if err != nil {
+		return nil, err
+	}
+	defer mrResp.Body.Close()
+
+	if mrResp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitLab API returned status %d", mrResp.StatusCode)
+	}
+
+	var mr struct {
+		State     string `json:"state"`
+		Title     string `json:"title"`
+		UpdatedAt string `json:"updated_at"`
+	}
+	if err := json.NewDecoder(mrResp.Body).Decode(&mr); err != nil {
+		return nil, err
+	}
+
+	// Obtener notes (comentarios)
+	notesURL := fmt.Sprintf("https://gitlab.com/api/v4/projects/%s/merge_requests/%d/notes?per_page=100", pid, number)
+	notesReq, _ := http.NewRequest("GET", notesURL, nil)
+	authHeader(notesReq)
+	notesResp, err := httpClient.Do(notesReq)
+	if err != nil {
+		return &provider.MRStatus{
+			State: mr.State, Title: mr.Title, Number: number,
+			Comments: 0, UpdatedAt: mr.UpdatedAt, Events: []provider.Event{},
+		}, nil
+	}
+	defer notesResp.Body.Close()
+
+	type note struct {
+		ID     int    `json:"id"`
+		Body   string `json:"body"`
+		Author struct {
+			Username string `json:"username"`
+		} `json:"author"`
+		CreatedAt string `json:"created_at"`
+		System    bool   `json:"system"`
+	}
+
+	var notes []note
+	if err := json.NewDecoder(notesResp.Body).Decode(&notes); err != nil {
+		notes = []note{}
+	}
+
+	comments := 0
+	events := make([]provider.Event, 0, len(notes))
+	for _, n := range notes {
+		eventType := "comment"
+		if n.System {
+			eventType = "system"
+		}
+		events = append(events, provider.Event{
+			Type: eventType, Author: n.Author.Username,
+			Body: n.Body, CreatedAt: n.CreatedAt,
+		})
+		if !n.System {
+			comments++
+		}
+	}
+
+	return &provider.MRStatus{
+		State: mr.State, Title: mr.Title, Number: number,
+		Comments: comments, UpdatedAt: mr.UpdatedAt, Events: events,
+	}, nil
 }
 
 // IsRepoVerified checks if the GitLab repo has a .gitgost.yml file.

--- a/internal/provider/gitlab/gitlab.go
+++ b/internal/provider/gitlab/gitlab.go
@@ -538,18 +538,23 @@ func (p *GitLabProvider) GetMRStatus(owner, repo string, number int) (*provider.
 		return nil, err
 	}
 
-	// Obtener notes (comentarios)
-	notesURL := fmt.Sprintf("https://gitlab.com/api/v4/projects/%s/merge_requests/%d/notes?per_page=100", pid, number)
-	notesReq, _ := http.NewRequest("GET", notesURL, nil)
-	authHeader(notesReq)
-	notesResp, err := httpClient.Do(notesReq)
-	if err != nil {
-		return &provider.MRStatus{
-			State: mr.State, Title: mr.Title, Number: number,
-			Comments: 0, UpdatedAt: mr.UpdatedAt, Events: []provider.Event{},
-		}, nil
+	// nextNotePageURL extrae la URL de la pagina siguiente del header Link de GitLab.
+	nextNotePageURL := func(linkHeader string) string {
+		if linkHeader == "" {
+			return ""
+		}
+		for _, part := range strings.Split(linkHeader, ",") {
+			part = strings.TrimSpace(part)
+			if strings.Contains(part, `rel="next"`) {
+				start := strings.Index(part, "<")
+				end := strings.Index(part, ">")
+				if start != -1 && end != -1 {
+					return part[start+1 : end]
+				}
+			}
+		}
+		return ""
 	}
-	defer notesResp.Body.Close()
 
 	type note struct {
 		ID     int    `json:"id"`
@@ -561,14 +566,41 @@ func (p *GitLabProvider) GetMRStatus(owner, repo string, number int) (*provider.
 		System    bool   `json:"system"`
 	}
 
-	var notes []note
-	if err := json.NewDecoder(notesResp.Body).Decode(&notes); err != nil {
-		notes = []note{}
+	var allNotes []note
+	notesURL := fmt.Sprintf("https://gitlab.com/api/v4/projects/%s/merge_requests/%d/notes?per_page=100&sort=desc", pid, number)
+	for notesURL != "" {
+		notesReq, _ := http.NewRequest("GET", notesURL, nil)
+		authHeader(notesReq)
+		notesResp, err := httpClient.Do(notesReq)
+		if err != nil {
+			// Si falla la primera pagina, retornar sin eventos
+			if len(allNotes) == 0 {
+				return &provider.MRStatus{
+					State: mr.State, Title: mr.Title, Number: number,
+					Comments: 0, UpdatedAt: mr.UpdatedAt, Events: []provider.Event{},
+				}, nil
+			}
+			break
+		}
+
+		var page []note
+		if err := json.NewDecoder(notesResp.Body).Decode(&page); err != nil {
+			notesResp.Body.Close()
+			if len(allNotes) == 0 {
+				page = []note{}
+			} else {
+				break
+			}
+		}
+		notesResp.Body.Close()
+
+		allNotes = append(allNotes, page...)
+		notesURL = nextNotePageURL(notesResp.Header.Get("Link"))
 	}
 
 	comments := 0
-	events := make([]provider.Event, 0, len(notes))
-	for _, n := range notes {
+	events := make([]provider.Event, 0, len(allNotes))
+	for _, n := range allNotes {
 		eventType := "comment"
 		if n.System {
 			eventType = "system"

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -18,6 +18,7 @@ type MRStatus struct {
 	Number    int     `json:"number"`
 	Comments  int     `json:"comments"`
 	UpdatedAt string  `json:"updated_at"`
+	ETag      string  `json:"etag,omitempty"`
 	Events    []Event `json:"events"`
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -11,6 +11,25 @@ type RepoPolicy struct {
 	DenyAll bool
 }
 
+// MRStatus contiene el estado actual de un Merge/Pull Request.
+type MRStatus struct {
+	State     string  `json:"state"`
+	Title     string  `json:"title"`
+	Number    int     `json:"number"`
+	Comments  int     `json:"comments"`
+	UpdatedAt string  `json:"updated_at"`
+	Events    []Event `json:"events"`
+}
+
+// Event representa un evento en el timeline de un MR/PR.
+type Event struct {
+	ID        string `json:"id,omitempty"`
+	Type      string `json:"type"`
+	Author    string `json:"author"`
+	Body      string `json:"body,omitempty"`
+	CreatedAt string `json:"created_at"`
+}
+
 // Provider abstracts the operations needed to anonymize contributions
 // across different git hosting platforms (GitHub, GitLab, etc.).
 type Provider interface {
@@ -58,4 +77,7 @@ type Provider interface {
 
 	// CreateAnonymousPRComment posts a comment on a PR/MR and returns the comment URL.
 	CreateAnonymousPRComment(owner, repo string, number int, body string) (string, error)
+
+	// GetMRStatus obtiene el estado actual de un MR/PR incluyendo su timeline de eventos.
+	GetMRStatus(owner, repo string, number int) (*MRStatus, error)
 }


### PR DESCRIPTION
Implement tracking of PRs/MRs created through gitGost and add /api/pr/:hash/status endpoint to retrieve their current status, timeline events, and comments. Include action buttons in ntfy notifications for quick status checks. Extends both GitHub and GitLab providers with GetMRStatus method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PR status checks now show richer, more up-to-date information, including recent activity and comments.
  * Status checks can now be retried against tracked pull/merge requests after notification actions.
  * GitLab merge request IDs are now handled more reliably from links.

* **Bug Fixes**
  * Improved retrieval of multi-page PR timelines.
  * Better handling of merged PR state detection.
  * Added request throttling for PR status checks to reduce overload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->