### PR TITLE
fix: simplify API base URL detection and relax CSP for localhost

### DIFF
--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -57,7 +57,7 @@ func securityHeaders() gin.HandlerFunc {
 				"img-src 'self' data: blob: https://*.amazonaws.com https://*.s3.amazonaws.com https://cdn.simpleicons.org; "+
 				"object-src 'none'; "+
 				"frame-ancestors 'none'; "+
-				"connect-src 'self' https://api.github.com https://raw.githubusercontent.com https://gitlab.com https://en.wikipedia.org https://www.wikidata.org",
+				"connect-src 'self' http://localhost:* https://api.github.com https://raw.githubusercontent.com https://gitlab.com https://en.wikipedia.org https://www.wikidata.org",
 		)
 		c.Next()
 	}

--- a/web/index.html
+++ b/web/index.html
@@ -1962,7 +1962,7 @@
         </div>
 
         <script>
-            const API_BASE = window.location.port === '8080' ? '' : 'http://localhost:8080';
+            const API_BASE = window.location.origin;
 
             // Modal functions
             function openModal(modalId) {

--- a/web/repo.html
+++ b/web/repo.html
@@ -1136,7 +1136,7 @@
     </div>
 
     <script>
-        const API_BASE = window.location.port === '8080' ? '' : 'http://localhost:8080';
+        const API_BASE = window.location.origin;
 
         // Suspension banner functions
         async function checkServiceStatus() {


### PR DESCRIPTION
Eliminada lógica condicional de detección de puerto en favor de `window.location.origin`. Actualizado CSP para permitir conexiones a `http://localhost:*` durante desarrollo local.