### PR TITLE
chore: expand CSP img-src to allow shields.io, trendshift.io, and sta…

### DIFF
--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -54,7 +54,7 @@ func securityHeaders() gin.HandlerFunc {
 				"script-src 'self' https://cdn.jsdelivr.net https://unpkg.com https://cdnjs.cloudflare.com 'unsafe-inline'; "+
 				"style-src 'self' https://fonts.googleapis.com https://cdnjs.cloudflare.com 'unsafe-inline'; "+
 				"font-src 'self' https://fonts.gstatic.com; "+
-				"img-src 'self' data: blob: https://*.amazonaws.com https://*.s3.amazonaws.com https://cdn.simpleicons.org; "+
+				"img-src 'self' data: blob: https://*.amazonaws.com https://*.s3.amazonaws.com https://cdn.simpleicons.org https://img.shields.io https://trendshift.io https://api.star-history.com; "+
 				"object-src 'none'; "+
 				"frame-ancestors 'none'; "+
 				"connect-src 'self' http://localhost:* https://api.github.com https://raw.githubusercontent.com https://gitlab.com https://en.wikipedia.org https://www.wikidata.org",


### PR DESCRIPTION
…r-history.com

Agregados dominios de badges y gráficos externos (shields.io, trendshift.io, star-history.com) a la política de seguridad de contenido para permitir carga de imágenes desde estos servicios.