### PR TITLE
feat: update clone/push commands to use original repo URLs with gost …

### DIFF
--- a/web/repo.html
+++ b/web/repo.html
@@ -2189,9 +2189,12 @@
             const base = rv.provider === 'gh'
                 ? `https://gitgost.fly.dev/v1/gh/${rv.owner}/${rv.repo}`
                 : `https://gitgost.fly.dev/v1/gl/${rv.owner}/${rv.repo}`;
+            const githubBase = rv.provider === 'gh'
+                ? `https://github.com/${rv.owner}/${rv.repo}`
+                : `https://gitlab.com/${rv.owner}/${rv.repo}`;
             const options = [
-                { label: 'clone / push',  cmd: `git clone ${base}/push` },
-                { label: 'push (update)', cmd: `git remote add origin ${base}/update` },
+                { label: 'clone / push',  cmd: `git clone ${githubBase} && cd ${rv.repo} && git remote add gost ${base}` },
+                { label: 'push (update)', cmd: `git remote add gost ${base}` },
             ];
             const overlay = document.createElement('div');
             overlay.id = 'clone-modal-overlay';


### PR DESCRIPTION
…remote

Modificados los comandos de clonación para usar las URLs originales de GitHub/GitLab en lugar de las URLs de gitGost, agregando gitGost como remote adicional llamado 'gost'. Simplificado el comando de actualización para usar el mismo patrón de remote naming.