### PR TITLE
feat: simplify clone command to use anonymous auth with gitGost URL d…

### DIFF
--- a/web/repo.html
+++ b/web/repo.html
@@ -2190,8 +2190,8 @@
                 ? `https://gitgost.fly.dev/v1/gh/${rv.owner}/${rv.repo}`
                 : `https://gitgost.fly.dev/v1/gl/${rv.owner}/${rv.repo}`;
             const options = [
-                { label: 'clone / push',  cmd: `git clone ${base}/push` },
-                { label: 'push (update)', cmd: `git remote add origin ${base}/update` },
+                { label: 'clone / push',  cmd: `git clone https://anon:@${base}` },
+                { label: 'push (update)', cmd: `git remote add gost ${base}` },
             ];
             const overlay = document.createElement('div');
             overlay.id = 'clone-modal-overlay';


### PR DESCRIPTION
…irectly

Eliminado el paso de clonar desde GitHub/GitLab y agregar remote 'gost' separadamente. Ahora el comando de clonación usa directamente la URL de gitGost con autenticación anónima (`anon:@`), simplificando el flujo de trabajo inicial.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the clone modal’s command so it now uses a simpler anonymous clone URL.
  * Removed the extra remote setup step from the displayed command, making the copy-paste instructions cleaner and easier to use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->