### PR TITLE
Fix clone/push URL construction

### DIFF
--- a/web/repo.html
+++ b/web/repo.html
@@ -2186,15 +2186,15 @@
 
         function doClone() {
             if (document.getElementById('clone-modal-overlay')) return;
-            const base = rv.provider === 'gh'
-                ? `https://gitgost.fly.dev/v1/gh/${rv.owner}/${rv.repo}`
-                : `https://gitgost.fly.dev/v1/gl/${rv.owner}/${rv.repo}`;
+            const host = rv.provider === 'gh'
+                ? `gitgost.fly.dev/v1/gh/${rv.owner}/${rv.repo}`
+                : `gitgost.fly.dev/v1/gl/${rv.owner}/${rv.repo}`;
             const githubBase = rv.provider === 'gh'
                 ? `https://github.com/${rv.owner}/${rv.repo}`
                 : `https://gitlab.com/${rv.owner}/${rv.repo}`;
             const options = [
-                { label: 'clone / push',  cmd: `git clone https://anon:@${base}` },
-                { label: 'push (update)', cmd: `git remote add gost ${base}` },
+                { label: 'clone / push',  cmd: `git clone https://anon:@${host}` },
+                { label: 'push (update)', cmd: `git remote add gost https://${host}` },
             ];
             const overlay = document.createElement('div');
             overlay.id = 'clone-modal-overlay';


### PR DESCRIPTION
Rename base -> host and separate the protocol from the host path. Explicitly prepend https:// for clone and remote-add commands so generated git URLs are consistent and correct. Updated web/repo.html.