### PR TITLE
Potential fix for code scanning alert no. 7: Exception text reinterpreted as HTML

### DIFF
--- a/web/repo.html
+++ b/web/repo.html
@@ -2090,7 +2090,10 @@
                     panel.innerHTML = '<div class="code-loading">no README</div>';
                 }
             } catch(e) {
-                panel.innerHTML = `<div class="code-loading" style="color:var(--accent)">error: ${e.message}</div>`;
+                panel.innerHTML = `<div class="code-loading" style="color:var(--accent)"></div>`;
+                const errEl = panel.querySelector('.code-loading');
+                const msg = (e && typeof e.message === 'string') ? e.message : String(e);
+                errEl.textContent = `error: ${msg}`;
             }
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/livrasand/gitGost/security/code-scanning/7](https://github.com/livrasand/gitGost/security/code-scanning/7)

The safest fix is to **stop injecting `e.message` into `innerHTML`**. Instead, render a static container with `innerHTML` (or create nodes), then assign the error text using `textContent`, which automatically escapes HTML meta-characters.

Best minimal change (without altering functionality/UI) in `web/repo.html` around lines 2092–2094:
1. Keep the same visual wrapper (`code-loading`, accent color).
2. Replace the interpolated `innerHTML` assignment with static HTML.
3. Set the dynamic error message through `textContent` on that new element.
4. Optionally normalize non-Error throws with `String(...)`.

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when loading repository documentation.
  * Error messages are now displayed safely and consistently without affecting page markup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->