### PR TITLE
Potential fix for code scanning alert no. 8: Exception text reinterpreted as HTML

### DIFF
--- a/web/repo.html
+++ b/web/repo.html
@@ -2311,7 +2311,8 @@
                 }
                 list.querySelectorAll('pre code').forEach(b => hljs.highlightElement(b));
             } catch(e) {
-                if (list) list.innerHTML = `<li style="list-style:none;font-family:'IBM Plex Mono',monospace;font-size:0.7rem;color:var(--accent);">error loading comments: ${e.message}</li>`;
+                const errMsg = escHtml((e && e.message) ? e.message : String(e));
+                if (list) list.innerHTML = `<li style="list-style:none;font-family:'IBM Plex Mono',monospace;font-size:0.7rem;color:var(--accent);">error loading comments: ${errMsg}</li>`;
             }
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/livrasand/gitGost/security/code-scanning/8](https://github.com/livrasand/gitGost/security/code-scanning/8)

The safest minimal fix is to stop inserting raw `e.message` into `innerHTML`. Since this file already uses `escHtml(...)`, the best low-impact change is to escape the error text before interpolation.

**What to change (web/repo.html):**
- In `loadIssueComments` catch block (around lines 2313–2315), replace `${e.message}` with an escaped string derived from the exception.
- Use a robust fallback so non-Error throws are handled:  
  `const errMsg = escHtml((e && e.message) ? e.message : String(e));`
- Then interpolate `${errMsg}` into the template assigned to `list.innerHTML`.

This preserves current functionality and visual output while preventing HTML/script interpretation of attacker-influenced exception content.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
