### PR TITLE
Potential fix for code scanning alert no. 10: Exception text reinterpreted as HTML

### DIFF
--- a/web/repo.html
+++ b/web/repo.html
@@ -4450,7 +4450,8 @@
                     panel.innerHTML = `<pre class="hljs" style="margin:0;padding:1.25rem 1.5rem;font-size:0.78rem;font-family:'IBM Plex Mono',monospace;line-height:1.65;background:var(--code-bg);color:var(--fg);white-space:pre-wrap;word-break:break-all;"><code>${highlighted}</code></pre>`;
                 }
             } catch (e) {
-                panel.innerHTML = `<div class="code-loading" style="color:var(--accent)">error al cargar: ${e.message}</div>`;
+                const safeErrorMessage = escHtml(e && e.message ? e.message : String(e));
+                panel.innerHTML = `<div class="code-loading" style="color:var(--accent)">error al cargar: ${safeErrorMessage}</div>`;
             }
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/livrasand/gitGost/security/code-scanning/10](https://github.com/livrasand/gitGost/security/code-scanning/10)

La forma correcta de corregirlo, sin cambiar funcionalidad, es **escapar metacaracteres HTML** del mensaje de error antes de interpolarlo en `innerHTML`. En este archivo ya existe `escHtml(...)` y se usa en otras zonas (breadcrumbs), así que la mejor solución es reutilizar esa función en el `catch`.

Cambio puntual en `web/repo.html`, dentro de `loadFile(item)`, bloque `catch (e)`:

- Reemplazar `${e.message}` por una versión escapada.
- Para robustez, convertir a string con fallback (`e && e.message ? e.message : String(e)`), luego pasar por `escHtml(...)`.

Esto mantiene el mismo HTML/estilo y evita interpretación de contenido malicioso.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
