### PR TITLE
Potential fix for code scanning alert no. 34: Incomplete HTML attribute sanitization

### DIFF
--- a/web/repo.html
+++ b/web/repo.html
@@ -4571,7 +4571,12 @@
         }
 
         function escHtml(s) {
-            return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+            return String(s)
+                .replace(/&/g,'&amp;')
+                .replace(/</g,'&lt;')
+                .replace(/>/g,'&gt;')
+                .replace(/"/g,'&quot;')
+                .replace(/'/g,'&#39;');
         }
 
         function decodeBase64Utf8(base64) {


### PR DESCRIPTION
Potential fix for [https://github.com/livrasand/gitGost/security/code-scanning/34](https://github.com/livrasand/gitGost/security/code-scanning/34)

The best fix is to make `escHtml` perform complete escaping for HTML contexts by also escaping quotes used in attributes (`"` and `'`). This preserves existing behavior while closing the gap flagged by CodeQL and protecting all current uses of `escHtml` in this file.

In `web/repo.html`, update the `escHtml` function (around line 4573–4575) so it escapes:
- `&` → `&amp;`
- `<` → `&lt;`
- `>` → `&gt;`
- `"` → `&quot;`
- `'` → `&#39;`

No new imports or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
