### PR TITLE
Potential fix for code scanning alert no. 31: DOM text reinterpreted as HTML

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2639,7 +2639,22 @@
                     const badge = item.querySelector('.repo-lang');
                     if (!badge) return;
                     const lang = badge.getAttribute('title');
-                    if (lang) badge.outerHTML = languageBadgeHtml(lang);
+                    if (!lang) return;
+
+                    badge.setAttribute('title', lang);
+
+                    let dot = badge.querySelector('.repo-lang-dot');
+                    if (!dot) {
+                        dot = document.createElement('span');
+                        dot.className = 'repo-lang-dot';
+                        badge.insertBefore(dot, badge.firstChild);
+                    }
+                    dot.style.background = languageColor(lang);
+
+                    Array.from(badge.childNodes).forEach(node => {
+                        if (node !== dot) badge.removeChild(node);
+                    });
+                    badge.appendChild(document.createTextNode(lang));
                 });
             }
 


### PR DESCRIPTION
Potential fix for [https://github.com/livrasand/gitGost/security/code-scanning/31](https://github.com/livrasand/gitGost/security/code-scanning/31)

Best fix: **stop rebuilding HTML via `outerHTML`** for data read from DOM; update DOM nodes using safe text/attribute/style APIs instead. This preserves functionality (refreshing badge text and color) while removing HTML reinterpretation.

In `web/index.html`:
- Replace line 2642 logic so it updates the existing `.repo-lang` node:
  - set `title` via `setAttribute`
  - ensure/create `.repo-lang-dot` child
  - set its `style.background`
  - set trailing text with `document.createTextNode(lang)` (not `innerHTML`)
- Keep `languageBadgeHtml` unchanged for other call sites, but this flagged flow no longer uses it.

No new imports or libraries are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
