### PR TITLE
Potential fix for code scanning alert no. 32: DOM text reinterpreted as HTML

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2958,10 +2958,24 @@
                             renderRepos(results);
                             updateStatusbar("search", query);
                         } else {
-                            if (container) container.innerHTML = '<p style="color:var(--fg-secondary);font-size:0.78rem;">No results for tag "' + query + '".</p>';
+                            if (container) {
+                                container.innerHTML = '';
+                                const p = document.createElement('p');
+                                p.style.color = 'var(--fg-secondary)';
+                                p.style.fontSize = '0.78rem';
+                                p.textContent = 'No results for tag "' + query + '".';
+                                container.appendChild(p);
+                            }
                         }
                     } else {
-                        if (container) container.innerHTML = '<p style="color:var(--fg-secondary);font-size:0.78rem;">No results for "' + query + '".</p>';
+                        if (container) {
+                            container.innerHTML = '';
+                            const p = document.createElement('p');
+                            p.style.color = 'var(--fg-secondary)';
+                            p.style.fontSize = '0.78rem';
+                            p.textContent = 'No results for "' + query + '".';
+                            container.appendChild(p);
+                        }
                     }
                 } catch (e) {
                     if (container) container.innerHTML = '<p style="color:var(--fg-secondary);font-size:0.78rem;">API not available.</p>';


### PR DESCRIPTION
Potential fix for [https://github.com/livrasand/gitGost/security/code-scanning/32](https://github.com/livrasand/gitGost/security/code-scanning/32)

Use safe DOM text insertion instead of HTML concatenation where untrusted `query` is displayed.

Best fix without changing behavior: replace the two vulnerable `innerHTML` assignments that include `query` (lines around 2961 and 2964) with DOM node creation (`document.createElement("p")`), set style properties, and assign message text via `textContent`. `textContent` ensures user input is treated as plain text, not parsed as HTML.

In `web/index.html`, inside `performSearch(query)`, update:
- the `No results for tag "..."` branch
- the `No results for "..."` branch

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
