### PR TITLE
Potential fix for code scanning alert no. 15: Client-side cross-site scripting

### DIFF
--- a/web/repo.html
+++ b/web/repo.html
@@ -2206,6 +2206,8 @@
             const url     = issue.html_url || issue.web_url || '#';
             const state   = issue.state || 'open';
             const body    = issue.body || issue.description || '';
+            const safeOwner = escHtml(rv.owner || '');
+            const safeRepo  = escHtml(rv.repo || '');
             const labels  = (issue.labels || []).map(l => {
                 const color = l.color ? `#${l.color}` : 'var(--border)';
                 return `<span class="issue-label" style="background:${color}22;border:1px solid ${color};color:${color};">${escHtml(l.name)}</span>`;
@@ -2229,7 +2231,7 @@
                             ${avatar ? `<img class="issue-detail-avatar" src="${avatar}" alt="${user}" />` : ''}
                             <strong style="color:var(--fg);">${escHtml(user)}</strong>
                             <span>opened ${created}</span>
-                            <span style="margin-left:auto;"><a class="issue-ext-link" href="${url}" target="_blank" rel="noopener">${rv.owner}/${rv.repo}#${num} <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24">
+                            <span style="margin-left:auto;"><a class="issue-ext-link" href="${url}" target="_blank" rel="noopener">${safeOwner}/${safeRepo}#${num} <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24">
 	<path d="M0 0h24v24H0z" fill="none" />
 	<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M10.25 3.75h-2.5a4 4 0 0 0-4 4v8.5a4 4 0 0 0 4 4h8.5a4 4 0 0 0 4-4v-2.5m-6.5-10h5.5c.276 0 .526.112.707.293m.293 6.207v-5.5a1 1 0 0 0-.293-.707M12.75 11.25l6.5-6.5l.707-.707" />
                             </svg>


### PR DESCRIPTION
Potential fix for [https://github.com/livrasand/gitGost/security/code-scanning/15](https://github.com/livrasand/gitGost/security/code-scanning/15)

General fix: never inject URL/query-derived strings directly into HTML parsed by `innerHTML`; encode them for HTML context first (or build DOM nodes with `textContent`).

Best minimal fix here (without changing behavior): in `showIssueDetail` in `web/repo.html`, escape `rv.owner` and `rv.repo` with the existing `escHtml(...)` helper before using them in the `panel.innerHTML` template, and use the escaped values in line 2232. This keeps the current rendering and layout unchanged while removing executable HTML injection from those query params.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
