### PR TITLE
Potential fix for code scanning alert no. 17: Client-side cross-site scripting

### DIFF
--- a/web/repo.html
+++ b/web/repo.html
@@ -2329,6 +2329,21 @@
             const overlay = document.createElement('div');
             overlay.id = 'bug-modal-overlay';
             overlay.className = 'bug-modal-overlay';
+            const escapeHtml = (s) => String(s).replace(/[&<>"']/g, c => (
+                c === '&' ? '&amp;' :
+                c === '<' ? '&lt;'  :
+                c === '>' ? '&gt;'  :
+                c === '"' ? '&quot;': '&#39;'
+            ));
+            const safeOwner = escapeHtml(rv.owner || '');
+            const safeRepo = escapeHtml(rv.repo || '');
+            const repoBase = rv.provider === 'cb'
+                ? 'https://codeberg.org'
+                : rv.provider === 'gh'
+                    ? 'https://github.com'
+                    : 'https://gitlab.com';
+            const repoHref = `${repoBase}/${safeOwner}/${safeRepo}`;
+            const repoLabel = `${safeOwner}/${safeRepo}`;
             overlay.innerHTML = `
                 <div class="bug-modal">
                     <div>
@@ -2347,7 +2362,7 @@
                         <menta-widget id="menta-bug" data-cap-api-endpoint="https://mentacaptchaeu.eu.pythonanywhere.com" data-cap-i18n-initial-state="I'm not a robot"></menta-widget>
                     </div>
                     <div class="bug-modal-footer">
-                        <span class="note">Anonymous issue in <a href="${rv.provider === 'cb' ? `https://codeberg.org/${rv.owner}/${rv.repo}` : rv.provider === 'gh' ? `https://github.com/${rv.owner}/${rv.repo}` : `https://gitlab.com/${rv.owner}/${rv.repo}`}" target="_blank">${rv.owner}/${rv.repo}</a></span>
+                        <span class="note">Anonymous issue in <a href="${repoHref}" target="_blank">${repoLabel}</a></span>
                         <div class="bug-modal-actions">
                             <span id="bug-status" style="font-family:'IBM Plex Mono',monospace;font-size:0.68rem;color:var(--fg-muted);"></span>
                             <button class="bug-cancel-btn" onclick="closeBugModal()">Cancel</button>


### PR DESCRIPTION
Potential fix for [https://github.com/livrasand/gitGost/security/code-scanning/17](https://github.com/livrasand/gitGost/security/code-scanning/17)

Best fix: perform contextual escaping for all untrusted values before interpolating into the `innerHTML` template. Here, escape `rv.owner` and `rv.repo` for HTML text/attribute contexts and construct the provider base URL from a fixed allowlist. This preserves functionality while preventing injected markup/script from being interpreted.

In `web/repo.html`, add a small HTML-escape helper near the modal code, compute `safeOwner`, `safeRepo`, `repoBase`, `repoHref`, and `repoLabel`, then use those safe variables inside the template literal on line 2350 instead of raw `rv.*`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
