### PR TITLE
Add 'updated' tab for recently active repositories

### DIFF
--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -3311,9 +3311,12 @@ func getTrendingGitHub(sort string, perPage, page int) []gin.H {
 	}
 
 	var url string
-	if sort == "new" {
+	switch sort {
+	case "new":
 		url = fmt.Sprintf("https://api.github.com/search/repositories?q=created:>%s&sort=updated&order=desc&per_page=%d&page=%d", dateCutoff, perPage, page)
-	} else {
+	case "updated":
+		url = fmt.Sprintf("https://api.github.com/search/repositories?q=pushed:>%s&sort=updated&order=desc&per_page=%d&page=%d", dateCutoff, perPage, page)
+	default:
 		url = fmt.Sprintf("https://api.github.com/search/repositories?q=created:>%s&sort=stars&order=desc&per_page=%d&page=%d", dateCutoff, perPage, page)
 	}
 
@@ -3348,6 +3351,9 @@ func getTrendingGitHub(sort string, perPage, page int) []gin.H {
 			Stargazers  int    `json:"stargazers_count"`
 			Forks       int    `json:"forks_count"`
 			Language    string `json:"language"`
+			CreatedAt   string `json:"created_at"`
+			UpdatedAt   string `json:"updated_at"`
+			PushedAt    string `json:"pushed_at"`
 		} `json:"items"`
 	}
 
@@ -3366,6 +3372,9 @@ func getTrendingGitHub(sort string, perPage, page int) []gin.H {
 			"stars":       item.Stargazers,
 			"forks":       item.Forks,
 			"language":    item.Language,
+			"created_at":  item.CreatedAt,
+			"updated_at":  item.UpdatedAt,
+			"pushed_at":   item.PushedAt,
 			"url":         fmt.Sprintf("/gh/%s/%s", item.Owner.Login, item.Name),
 		})
 	}
@@ -3376,16 +3385,20 @@ func getTrendingGitHub(sort string, perPage, page int) []gin.H {
 func getTrendingGitLab(sort string, perPage, page int) []gin.H {
 	results := []gin.H{}
 
-	var url string
-	if sort == "new" {
-		url = fmt.Sprintf("https://gitlab.com/api/v4/projects?order_by=created_at&sort=desc&per_page=%d&page=%d", perPage, page)
-	} else {
-		url = fmt.Sprintf("https://gitlab.com/api/v4/projects?order_by=star_count&sort=desc&per_page=%d&page=%d", perPage, page)
+	var apiURL string
+	switch sort {
+	case "new":
+		apiURL = fmt.Sprintf("https://gitlab.com/api/v4/projects?order_by=created_at&sort=desc&per_page=%d&page=%d", perPage, page)
+	case "updated":
+		since := time.Now().UTC().AddDate(0, 0, -30).Format(time.RFC3339)
+		apiURL = fmt.Sprintf("https://gitlab.com/api/v4/projects?order_by=last_activity_at&sort=desc&last_activity_after=%s&per_page=%d&page=%d", url.QueryEscape(since), perPage, page)
+	default:
+		apiURL = fmt.Sprintf("https://gitlab.com/api/v4/projects?order_by=star_count&sort=desc&per_page=%d&page=%d", perPage, page)
 	}
 
 	glToken := os.Getenv("GITLAB_TOKEN")
 	client := &http.Client{Timeout: 10 * time.Second}
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest("GET", apiURL, nil)
 	if err != nil {
 		return results
 	}
@@ -3415,6 +3428,9 @@ func getTrendingGitLab(sort string, perPage, page int) []gin.H {
 		Namespace         struct {
 			Path string `json:"path"`
 		} `json:"namespace"`
+		CreatedAt      string `json:"created_at"`
+		UpdatedAt      string `json:"updated_at"`
+		LastActivityAt string `json:"last_activity_at"`
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
@@ -3447,6 +3463,10 @@ func getTrendingGitLab(sort string, perPage, page int) []gin.H {
 			language = langs[i]
 		}
 
+		updatedAt := item.UpdatedAt
+		if item.LastActivityAt != "" {
+			updatedAt = item.LastActivityAt
+		}
 		results = append(results, gin.H{
 			"provider":    "gitlab",
 			"name":        item.Name,
@@ -3456,6 +3476,8 @@ func getTrendingGitLab(sort string, perPage, page int) []gin.H {
 			"stars":       item.StarCount,
 			"forks":       item.ForksCount,
 			"language":    language,
+			"created_at":  item.CreatedAt,
+			"updated_at":  updatedAt,
 			"url":         fmt.Sprintf("/gl/%s/%s", owner, item.Name),
 		})
 	}
@@ -3471,10 +3493,14 @@ func getTrendingCodeberg(sort string, perPage, page int) []gin.H {
 	if page > 1 {
 		params.Set("page", strconv.Itoa(page))
 	}
-	if sort == "new" {
+	switch sort {
+	case "new":
 		params.Set("sort", "created")
 		params.Set("order", "desc")
-	} else {
+	case "updated":
+		params.Set("sort", "updated")
+		params.Set("order", "desc")
+	default:
 		params.Set("sort", "stars")
 		params.Set("order", "desc")
 	}
@@ -3512,6 +3538,8 @@ func getTrendingCodeberg(sort string, perPage, page int) []gin.H {
 			Owner       struct {
 				Login string `json:"login"`
 			} `json:"owner"`
+			CreatedAt string `json:"created_at"`
+			UpdatedAt string `json:"updated_at"`
 		} `json:"data"`
 	}
 
@@ -3537,6 +3565,8 @@ func getTrendingCodeberg(sort string, perPage, page int) []gin.H {
 			"stars":       item.Stars,
 			"forks":       item.Forks,
 			"language":    item.Language,
+			"created_at":  item.CreatedAt,
+			"updated_at":  item.UpdatedAt,
 			"url":         fmt.Sprintf("/cb/%s/%s", owner, item.Name),
 		})
 	}

--- a/web/index.html
+++ b/web/index.html
@@ -1605,6 +1605,13 @@
                     </button>
                     <button
                         class="content-tab"
+                        data-tab="updated"
+                        onclick="switchTab('updated', this)"
+                    >
+                        updated
+                    </button>
+                    <button
+                        class="content-tab"
                         data-tab="stars"
                         onclick="switchTab('stars', this)"
                     >
@@ -3016,10 +3023,11 @@
                         : "";
                     const count =
                         repo.stars > 0 ? `(${formatNumber(repo.stars)})` : "";
+                    const isDateTab = scrollState.tab === 'new' || scrollState.tab === 'updated';
                     const dateStr = scrollState.tab === 'new'
                         ? (repo.created_at || repo.updated_at || repo.pushed_at || '')
-                        : (repo.pushed_at || repo.updated_at || repo.created_at || '');
-                    const ago = scrollState.tab === 'new' ? timeAgo(dateStr) : '';
+                        : (repo.updated_at || repo.pushed_at || repo.created_at || '');
+                    const ago = isDateTab ? timeAgo(dateStr) : '';
                     const langBadge = languageBadgeHtml(repo.language);
 
                     let providerLabel, providerColor;
@@ -3057,6 +3065,8 @@
                     loadTrending();
                 } else if (tab === "new") {
                     loadNew();
+                } else if (tab === "updated") {
+                    loadUpdated();
                 } else if (tab === "stars") {
                     loadStars();
                 } else if (tab === "popular") {
@@ -3226,6 +3236,41 @@
                 }
             }
 
+            async function loadUpdated(append = false) {
+                if (scrollState.loading || scrollState.exhausted) return;
+                scrollState.loading = true;
+                const container = document.getElementById('repo-list');
+                if (!append) {
+                    if (container) container.innerHTML = '<p style="color:var(--fg-secondary);font-size:0.78rem;">Loading recently updated repos...</p>';
+                } else {
+                    appendSkeletons();
+                }
+                try {
+                    const response = await fetch(`${API_BASE}/api/trending/all?sort=updated&page=${scrollState.page}`);
+                    if (!response.ok) { scrollState.exhausted = true; removeSentinel(); return; }
+                    const text = await response.text();
+                    let data;
+                    try { data = JSON.parse(text); } catch { scrollState.exhausted = true; removeSentinel(); return; }
+                    const results = data.results || [];
+                    if (results.length > 0) {
+                        renderRepos(results, append);
+                        updateStatusbar('updated');
+                        scrollState.page++;
+                        ensureSentinel();
+                    } else {
+                        scrollState.exhausted = true;
+                        removeSentinel();
+                        if (!append && container) container.innerHTML = '<p style="color:var(--fg-secondary);font-size:0.78rem;">No recently updated repos available.</p>';
+                    }
+                } catch {
+                    scrollState.exhausted = true;
+                    removeSentinel();
+                    if (!append && container) container.innerHTML = '<p style="color:var(--fg-secondary);font-size:0.78rem;">API not available.</p>';
+                } finally {
+                    scrollState.loading = false;
+                }
+            }
+
             function shuffleArray(array) {
                 for (let i = array.length - 1; i > 0; i--) {
                     const j = Math.floor(Math.random() * (i + 1));
@@ -3305,6 +3350,7 @@
                             if (callback) callback();
                             else if (scrollState.tab === 'trending') loadTrending(true);
                             else if (scrollState.tab === 'new') loadNew(true);
+                            else if (scrollState.tab === 'updated') loadUpdated(true);
                         }
                     }, { root, rootMargin: '200px' });
                 }


### PR DESCRIPTION
Adds a new 'updated' sorting option to trending endpoints and UI. Backend now supports sort=updated for GitHub (pushed_at), GitLab (last_activity_at), and Codeberg (updated). Refactored if/else chains to switch statements in getTrendingGitHub, getTrendingGitLab, and getTrendingCodeberg. Added timestamp fields (created_at, updated_at, pushed_at/last_activity_at) to API responses. Frontend adds 'updated' tab button, loadUpdated function with pagination, and displays time-ago for both