### PR TITLE
Potential fix for code scanning alert no. 37: Exception text reinterpreted as HTML

### DIFF
--- a/web/repo.html
+++ b/web/repo.html
@@ -2706,7 +2706,8 @@
                     try { hljs.highlightElement(b); } catch(_) {}
                 });
             } catch(e) {
-                panel.innerHTML = `<div class="code-loading" style="color:var(--accent)">error: ${e.message}</div>`;
+                const safeMsg = escHtml((e && e.message != null) ? String(e.message) : String(e));
+                panel.innerHTML = `<div class="code-loading" style="color:var(--accent)">error: ${safeMsg}</div>`;
             }
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/livrasand/gitGost/security/code-scanning/37](https://github.com/livrasand/gitGost/security/code-scanning/37)

The safest fix is to stop inserting exception text through `innerHTML` and instead render it as text content, so the browser never interprets message characters as markup.

Best minimal change (without changing functionality): in `web/repo.html` around lines 2708–2710, keep the same visual wrapper but sanitize `e.message` before interpolation using the existing `escHtml(...)` helper already used elsewhere in this file (for example at line 2624). Also normalize non-Error throws to a string safely.

Concretely:
- Edit only the `catch(e)` block in `web/repo.html`.
- Introduce a local `safeMsg` derived from `e?.message ?? String(e)` and escaped with `escHtml(...)`.
- Use `safeMsg` in the template assigned to `panel.innerHTML`.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved discussion-detail error handling by safely formatting error messages before displaying them.
  * Prevented special characters in errors from being interpreted as HTML.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->