### PR TITLE
Potential fix for code scanning alert no. 19: Client-side cross-site scripting

### DIFF
--- a/web/repo.html
+++ b/web/repo.html
@@ -2656,7 +2656,7 @@
                             <div class="issue-detail-meta">
                                 <strong style="color:var(--fg);">${escHtml(user)}</strong>
                                 <span>opened ${created}</span>
-                                <span style="margin-left:auto;"><a class="issue-ext-link" href="${url}" target="_blank" rel="noopener">${rv.owner}/${rv.repo}#${num} <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24">
+                                <span style="margin-left:auto;"><a class="issue-ext-link" href="${url}" target="_blank" rel="noopener">${escHtml(rv.owner)}/${escHtml(rv.repo)}#${num} <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24">
 	<path d="M0 0h24v24H0z" fill="none" />
 	<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M10.25 3.75h-2.5a4 4 0 0 0-4 4v8.5a4 4 0 0 0 4 4h8.5a4 4 0 0 0 4-4v-2.5m-6.5-10h5.5c.276 0 .526.112.707.293m.293 6.207v-5.5a1 1 0 0 0-.293-.707M12.75 11.25l6.5-6.5l.707-.707" />
                                 </svg>


### PR DESCRIPTION
Potential fix for [https://github.com/livrasand/gitGost/security/code-scanning/19](https://github.com/livrasand/gitGost/security/code-scanning/19)

General fix: never place URL/query/user-controlled strings into `innerHTML` without escaping/sanitization. For text context inside HTML, apply HTML escaping before interpolation.

Best minimal fix here (no behavior change): escape `rv.owner` and `rv.repo` at the interpolation point in the template literal used for `panel.innerHTML` in `showDiscussionDetail`. This file already uses `escHtml(...)`, so reuse that function consistently.

Change needed:
- **File:** `web/repo.html`
- **Region:** around line 2659 in the `panel.innerHTML = \`...\`` block inside `showDiscussionDetail`
- Replace `${rv.owner}/${rv.repo}#${num}` with `${escHtml(rv.owner)}/${escHtml(rv.repo)}#${num}`.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
