### PR TITLE
Potential fix for code scanning alert no. 20: Client-side cross-site scripting

### DIFF
--- a/web/repo.html
+++ b/web/repo.html
@@ -2842,6 +2842,8 @@
                         }
                     } catch(_) { /* sidebar no disponible */ }
 
+                    const safeOwner = encodeURIComponent(rv.owner || '');
+                    const safeRepo = encodeURIComponent(rv.repo || '');
                     let navHtml = '';
                     if (navPages.length > 0) {
                         navHtml = `<div style="padding:0.75rem 1.25rem;border-bottom:1px solid var(--border);font-size:0.72rem;font-family:'IBM Plex Mono',monospace;color:var(--fg-muted);display:flex;gap:0.5rem;flex-wrap:wrap;">
@@ -2850,11 +2852,11 @@
                                 const target = p.slug + (p.anchor ? '#' + p.anchor : '');
                                 return `<a href="#" data-wiki="${escAttr(target)}" style="color:${active ? 'var(--accent)' : 'var(--fg-muted)'};text-decoration:none;padding:0.15rem 0.4rem;border:1px solid ${active ? 'var(--accent)' : 'var(--border)'};border-radius:3px;">${escHtml(p.title)}</a>`;
                             }).join('')}
-                            <a href="https://github.com/${rv.owner}/${rv.repo}/wiki" target="_blank" style="color:var(--accent);text-decoration:none;padding:0.15rem 0.4rem;">Open on GitHub ↗</a>
+                            <a href="https://github.com/${safeOwner}/${safeRepo}/wiki" target="_blank" style="color:var(--accent);text-decoration:none;padding:0.15rem 0.4rem;">Open on GitHub ↗</a>
                         </div>`;
                     } else {
                         navHtml = `<div style="padding:0.5rem 1.25rem 1rem;font-size:0.72rem;font-family:'IBM Plex Mono',monospace;color:var(--fg-muted);">
-                            <a href="https://github.com/${rv.owner}/${rv.repo}/wiki" target="_blank" style="color:var(--accent);">Open wiki on GitHub ↗</a>
+                            <a href="https://github.com/${safeOwner}/${safeRepo}/wiki" target="_blank" style="color:var(--accent);">Open wiki on GitHub ↗</a>
                         </div>`;
                     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/livrasand/gitGost/security/code-scanning/20](https://github.com/livrasand/gitGost/security/code-scanning/20)

To fix this without changing behavior, keep the current rendering model but ensure all URL-query-derived values used inside HTML template literals are safely encoded for their context before interpolation.

Best single fix in this snippet:
- In `web/repo.html`, inside `loadWiki(page)`, before constructing `navHtml`, compute encoded variants of `rv.owner` and `rv.repo` using `encodeURIComponent`.
- Use those encoded values in both GitHub wiki `<a href="...">` template literals (lines around 2853 and 2857).
- This prevents attacker-controlled characters from altering HTML/attribute structure when `navHtml` is assigned to `innerHTML`, while preserving functional links.

No new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
