### PR TITLE
fix: unset ANDROID_SDK_ROOT before building Android APK

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -46,7 +46,9 @@ jobs:
         run: chmod +x ./android/gradlew
 
       - name: Build debug APK
-        run: ./gradlew assembleDebug
+        run: |
+          unset ANDROID_SDK_ROOT
+          ./gradlew assembleDebug
         working-directory: ./android
 
       - name: Prepare artifact


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of Android debug APK builds by ensuring the build process uses the intended SDK configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->