### PR TITLE
fix: change splash screen parent theme from Theme.SplashScreen to App…

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -16,7 +16,7 @@
     </style>
 
 
-    <style name="AppTheme.NoActionBarLaunch" parent="Theme.SplashScreen">
+    <style name="AppTheme.NoActionBarLaunch" parent="AppTheme.NoActionBar">
         <item name="android:background">@drawable/splash</item>
     </style>
 </resources>


### PR DESCRIPTION
…Theme.NoActionBar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android app startup styling by ensuring the launch screen uses the standard application theme while preserving its splash background.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->