### PR TITLE
Add GitGost logo drawable for Android

### DIFF
--- a/android/app/src/main/res/drawable/gitgost_logo.xml
+++ b/android/app/src/main/res/drawable/gitgost_logo.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Vector version of web/assets/logos/gitgost-logo.svg (16x16 viewport). -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="96dp"
+    android:height="96dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+    <path
+        android:fillColor="#FC6D26"
+        android:fillType="evenOdd"
+        android:pathData="M0 0C3.22.01 4.967.573 8 2C11.033.573 12.78.01 16 0V14C12.767 14.033 11.022 14.611 8 16C4.978 14.611 3.233 14.033 0 14V0Z" />
+    <group
+        android:translateX="3"
+        android:translateY="3"
+        android:scaleX="0.1"
+        android:scaleY="0.1">
+        <path
+            android:fillColor="#FFFFFF"
+            android:pathData="m50 8.332c-18.383 0-33.332 14.949-33.332 33.336v41.664c0 4.5781 3.7539 8.3359 8.332 8.3359 3.4258 0 6.25-2.8242 6.25-6.25v-4.168c0-1.1758 0.90625-2.082 2.082-2.082s2.0859 0.90625 2.0859 2.082v4.168c0 3.4258 2.8203 6.25 6.25 6.25 3.4258 0 6.25-2.8242 6.25-6.25v-4.168c0-1.1758 0.90625-2.082 2.082-2.082s2.082 0.90625 2.082 2.082v4.168c0 3.4258 2.8242 6.25 6.25 6.25 3.4297 0 6.25-2.8242 6.25-6.25v-4.168c0-1.1758 0.91016-2.082 2.0859-2.082s2.082 0.90625 2.082 2.082v4.168c0 3.4258 2.8242 6.25 6.25 6.25 4.5781 0 8.332-3.7578 8.332-8.3359v-41.664c0-18.387-14.949-33.336-33.332-33.336z" />
+    </group>
+</vector>

--- a/android/app/src/main/res/drawable/launch_background.xml
+++ b/android/app/src/main/res/drawable/launch_background.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:drawable="@color/colorPrimary" />
-    <item>
-        <bitmap
-            android:gravity="center"
-            android:src="@drawable/gitgost_logo" />
-    </item>
+    <item
+        android:drawable="@drawable/gitgost_logo"
+        android:gravity="center" />
 </layer-list>


### PR DESCRIPTION
Adds a new vector drawable for the GitGost logo (gitgost_logo.xml) to be used in the Android app. Also refactors launch_background.xml to simplify the layout by using the android:drawable attribute directly instead of nested bitmap elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added a branded GitGost logo for Android.
  * Updated the Android launch screen to display the logo centered on the background.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->