### PR TITLE
Update uuid to 11.1.1 and add override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2398,14 +2398,17 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
     "@capacitor/cli": "^8.5.0",
     "@openai/codex-security": "^0.1.6"
   },
+  "overrides": {
+    "xcode": {
+      "uuid": "^11.1.1"
+    }
+  },
   "scripts": {
     "cap:sync": "npx cap sync",
     "cap:android": "npx cap run android",


### PR DESCRIPTION
Bump uuid from 7.0.3 to 11.1.1 in package-lock.json (updated resolved URL, integrity, bin -> dist/esm/bin/uuid, added funding entries). Add package.json "overrides" to force xcode to use uuid@^11.1.1 so the project uses the modern ESM-compatible uuid and avoids the deprecated older release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s build tooling requirements to use the specified Xcode version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->