### PR TITLE
Update gitGost URL and anonymity disclaimer

### DIFF
--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -285,7 +285,7 @@ func CreateAnonymousIssue(owner, repo, title, body string, labels []string) (str
 
 	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/issues", owner, repo)
 
-	issueBody := fmt.Sprintf("%s\n\n---\n\n*This is an anonymous contribution made via [gitGost](https://gitgost.fly.dev).*\n\n*The original author's identity has been anonymized to protect their privacy.*", body)
+	issueBody := fmt.Sprintf("%s\n\n---\n\n*This is an anonymous contribution made via [gitGost](https://gitgost.livrasand.com).*\n\n*The original author's identity has been anonymized to protect their privacy. This is a service account that allows real humans to contribute anonymously.*", body)
 
 	payload := map[string]interface{}{
 		"title":  title,
@@ -649,7 +649,7 @@ func CreatePR(owner, repo, branch, forkOwner, commitMessage string) (string, err
 
 	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/pulls", owner, repo)
 
-	prBody := fmt.Sprintf("%s\n\n---\n\n*This is an anonymous contribution made via [gitGost](https://gitgost.fly.dev).*\n\n*The original author's identity has been anonymized to protect their privacy.*", commitMessage)
+	prBody := fmt.Sprintf("%s\n\n---\n\n*This is an anonymous contribution made via [gitGost](https://gitgost.livrasand.com).*\n\n*The original author's identity has been anonymized to protect their privacy. This is a service account that allows real humans to contribute anonymously.*", commitMessage)
 
 	data := map[string]interface{}{
 		"title": "Anonymous contribution via gitGost",

--- a/internal/provider/codeberg/codeberg.go
+++ b/internal/provider/codeberg/codeberg.go
@@ -201,7 +201,7 @@ func (p *CodebergProvider) CreateMR(owner, repo, branch, forkOwner, commitMessag
 		body = ""
 	}
 
-	body += "\n\n---\n\n*This is an anonymous contribution made via [gitGost](https://gitgost.fly.dev).*\n\n*The original author's identity has been anonymized to protect their privacy.*"
+	body += "\n\n---\n\n*This is an anonymous contribution made via [gitGost](https://gitgost.livrasand.com).*\n\n*The original author's identity has been anonymized to protect their privacy. This is a service account that allows real humans to contribute anonymously.*"
 
 	payload := map[string]interface{}{
 		"title": title,

--- a/internal/provider/gitlab/gitlab.go
+++ b/internal/provider/gitlab/gitlab.go
@@ -139,7 +139,7 @@ func (p *GitLabProvider) CreateMR(owner, repo, branch, forkOwner, commitMessage 
 
 	apiURL := fmt.Sprintf("https://gitlab.com/api/v4/projects/%s/merge_requests", projectID(owner, repo))
 
-	mrBody := fmt.Sprintf("%s\n\n---\n\n*This is an anonymous contribution made via [gitGost](https://gitgost.fly.dev).*\n\n*The original author's identity has been anonymized to protect their privacy.*", commitMessage)
+	mrBody := fmt.Sprintf("%s\n\n---\n\n*This is an anonymous contribution made via [gitGost](https://gitgost.livrasand.com).*\n\n*The original author's identity has been anonymized to protect their privacy. This is a service account that allows real humans to contribute anonymously.*", commitMessage)
 
 	payload := map[string]interface{}{
 		"source_branch":       branch,


### PR DESCRIPTION
Update the domain from gitgost.fly.dev to gitgost.livrasand.com and enhance the anonymity disclaimer footer in anonymous contributions across GitHub, Codeberg, and GitLab providers. The updated footer now clarifies that this is a service account enabling real humans to contribute anonymously.