### PR TITLE
Allow per-request GitHub token passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,11 +136,11 @@ Done. The PR appears instantly from `@gitgost-anonymous` with your commit messag
 
 ## Use Your Own Service Account
 
-gitGost works without an account or personal access token. However, you can optionally create a dedicated **service account** on GitHub or GitLab and add its token to the gitGost service.
+gitGost works without an account or personal access token. If you want, you can connect a dedicated **service account** and let gitGost use that identity for GitHub actions instead of the shared operator-managed one.
 
-Using your own service account can provide gitGost with a dedicated API identity and rate limit instead of relying entirely on shared credentials.
+This is optional. It is useful when you want your own rate limit, your own account ownership, or a simpler trust model.
 
-> **Important:** Create a dedicated account for gitGost. Do not use your personal GitHub or GitLab account.
+> **Important:** create a dedicated account for gitGost. Do not use your personal GitHub or GitLab account.
 
 ### GitHub
 
@@ -160,15 +160,23 @@ Create a dedicated GitHub account for gitGost and generate a **Personal Access T
 
 The link above pre-configures the token with the recommended scopes and no expiration.
 
-After creating the token, store it securely and configure it in your gitGost deployment.
+If you are using the CLI, pass the token directly with `git push`:
 
-> **Security:** Treat the token like a password. Never commit it to a repository, expose it in client-side code, or share it publicly.
+```bash
+git push gost fix-typo:main -o github-token=ghp_your_service_account_token
+```
 
-#### Recommended:
+Replace the value with your service account token. gitGost reads that push option and uses that account for the GitHub-side action.
+
+After creating the token, store it securely and configure it in your gitGost deployment or in the web settings if you are using the browser UI.
+
+> **Security:** treat the token like a password. Never commit it to a repository, expose it in client-side code, or share it publicly.
+
+#### Recommended
 
 <p align="center">
   <img src="./web/assets/screenshots/conf_1.png" width="100%" />
- </p> 
+</p>
 
 ### GitLab
 
@@ -184,17 +192,17 @@ The link above pre-configures the token with the recommended `api` scope.
 
 After creating the token, store it securely and configure it in your gitGost deployment.
 
-> **Security:** Treat the token like a password. Never commit it to a repository, expose it in client-side code, or share it publicly.
+> **Security:** treat the token like a password. Never commit it to a repository, expose it in client-side code, or share it publicly.
 
 ### Why use a service account?
 
-A dedicated service account allows gitGost to:
+A dedicated service account lets gitGost:
 
-- Use a separate identity for API requests.
-- Avoid using the maintainer's personal account.
-- Provide an independent API rate limit.
-- Rotate or revoke credentials without affecting personal accounts.
-- Add multiple accounts to a credential pool when operating a larger gitGost deployment.
+- use a separate identity for API requests,
+- avoid using the maintainer's personal account,
+- use an independent API rate limit,
+- rotate or revoke credentials without affecting personal accounts,
+- support larger deployments with multiple pooled accounts.
 
 ## Download Android app
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -18,7 +18,7 @@ func TestPushToGitHub_NoToken(t *testing.T) {
 
 	os.Unsetenv("GITHUB_TOKEN")
 
-	_, err := PushToGitHub("owner", "repo", "/tmp/nonexistent", "forkowner", "", "", "")
+	_, err := PushToGitHub("owner", "repo", "/tmp/nonexistent", "forkowner", "", "", "", "")
 	if err == nil {
 		t.Error("Expected error when GITHUB_TOKEN is not set")
 	}
@@ -38,7 +38,7 @@ func TestReceivePack(t *testing.T) {
 	}()
 
 	os.Unsetenv("GITHUB_TOKEN")
-	_, _, _, err := ReceivePack(tempDir, []byte{}, "owner", "repo", "", "")
+	_, _, _, _, err := ReceivePack(tempDir, []byte{}, "owner", "repo", "", "", "")
 	if err == nil {
 		t.Error("Expected error when GITHUB_TOKEN is not set")
 	}

--- a/internal/git/push.go
+++ b/internal/git/push.go
@@ -3,6 +3,7 @@ package git
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/go-git/go-git/v5"
@@ -17,11 +18,14 @@ func min(a, b int) int {
 	return b
 }
 
-func PushToGitHub(owner, repo, tempDir, forkOwner, targetBranch string, pushURL string, tokenEnvVar string) (string, error) {
+func PushToGitHub(owner, repo, tempDir, forkOwner, targetBranch string, pushURL string, tokenEnvVar string, tokenOverride string) (string, error) {
 	if tokenEnvVar == "" {
 		tokenEnvVar = "GITHUB_TOKEN"
 	}
-	token := os.Getenv(tokenEnvVar)
+	token := strings.TrimSpace(tokenOverride)
+	if token == "" {
+		token = os.Getenv(tokenEnvVar)
+	}
 	if token == "" {
 		return "", fmt.Errorf("%s not set", tokenEnvVar)
 	}

--- a/internal/git/receive.go
+++ b/internal/git/receive.go
@@ -61,10 +61,11 @@ type RefUpdate struct {
 	Ref    string
 }
 
-func ExtractPackfile(body []byte) ([]byte, *RefUpdate, string, error) {
+func ExtractPackfile(body []byte) ([]byte, *RefUpdate, string, string, error) {
 	reader := bytes.NewReader(body)
 	var refUpdate *RefUpdate
 	var prHash string
+	var githubToken string
 
 	for {
 		line, err := ParsePktLine(reader)
@@ -72,7 +73,7 @@ func ExtractPackfile(body []byte) ([]byte, *RefUpdate, string, error) {
 			if err == io.EOF {
 				break
 			}
-			return nil, nil, "", fmt.Errorf("error parsing pkt-line: %v", err)
+			return nil, nil, "", "", fmt.Errorf("error parsing pkt-line: %v", err)
 		}
 
 		if line == nil {
@@ -80,12 +81,26 @@ func ExtractPackfile(body []byte) ([]byte, *RefUpdate, string, error) {
 		}
 
 		lineStr := string(line)
-		debugf("DEBUG: Command line: %q\n", lineStr)
+		safeLine := lineStr
+		if strings.HasPrefix(lineStr, "push-option=") {
+			if idx := strings.Index(lineStr, "github-token="); idx >= 0 {
+				safeLine = lineStr[:idx+len("github-token=")] + "<redacted>"
+			} else if idx := strings.Index(lineStr, "token="); idx >= 0 {
+				safeLine = lineStr[:idx+len("token=")] + "<redacted>"
+			}
+		}
+		debugf("DEBUG: Command line: %q\n", safeLine)
 
 		if strings.HasPrefix(lineStr, "push-option=pr-hash=") {
 			prHash = strings.TrimPrefix(lineStr, "push-option=pr-hash=")
 			prHash = strings.TrimRight(prHash, "\n")
 			debugf("DEBUG: Found pr-hash push-option: %s\n", prHash)
+			continue
+		}
+		if strings.HasPrefix(lineStr, "push-option=github-token=") {
+			githubToken = strings.TrimPrefix(lineStr, "push-option=github-token=")
+			githubToken = strings.TrimRight(githubToken, "\n")
+			debugf("DEBUG: Found github-token push-option\n")
 			continue
 		}
 
@@ -102,12 +117,12 @@ func ExtractPackfile(body []byte) ([]byte, *RefUpdate, string, error) {
 		if strings.Contains(lineStr, "PACK") {
 			currentPos, err := reader.Seek(0, io.SeekCurrent)
 			if err != nil {
-				return nil, nil, "", fmt.Errorf("failed to determine pack start: %v", err)
+				return nil, nil, "", "", fmt.Errorf("failed to determine pack start: %v", err)
 			}
 			packStart := currentPos - int64(len(line))
 			_, err = reader.Seek(packStart, io.SeekStart)
 			if err != nil {
-				return nil, nil, "", fmt.Errorf("failed to seek pack start: %v", err)
+				return nil, nil, "", "", fmt.Errorf("failed to seek pack start: %v", err)
 			}
 			break
 		}
@@ -115,13 +130,13 @@ func ExtractPackfile(body []byte) ([]byte, *RefUpdate, string, error) {
 
 	packfile, err := io.ReadAll(reader)
 	if err != nil {
-		return nil, nil, "", err
+		return nil, nil, "", "", err
 	}
 
 	if len(packfile) < 4 || !bytes.Equal(packfile[:4], []byte("PACK")) {
 		packStart := bytes.Index(body, []byte("PACK"))
 		if packStart == -1 {
-			return nil, nil, "", fmt.Errorf("no packfile found in body")
+			return nil, nil, "", "", fmt.Errorf("no packfile found in body")
 		}
 		packfile = body[packStart:]
 	}
@@ -129,25 +144,40 @@ func ExtractPackfile(body []byte) ([]byte, *RefUpdate, string, error) {
 	debugf("DEBUG: Extracted packfile: %d bytes, starts with: %x\n",
 		len(packfile), packfile[:min(20, len(packfile))])
 
-	return packfile, refUpdate, prHash, nil
+	return packfile, refUpdate, prHash, githubToken, nil
 }
 
-func ReceivePack(tempDir string, body []byte, owner string, repo string, cloneURL string, tokenEnvVar string) (string, string, string, error) {
+func ReceivePack(tempDir string, body []byte, owner string, repo string, cloneURL string, tokenEnvVar string, tokenOverride string) (string, string, string, string, error) {
 	if cloneURL == "" {
 		cloneURL = fmt.Sprintf("https://github.com/%s/%s.git", owner, repo)
 	}
 	if tokenEnvVar == "" {
 		tokenEnvVar = "GITHUB_TOKEN"
 	}
-	token := os.Getenv(tokenEnvVar)
+	if len(body) == 0 {
+		return "", "", "", "", nil
+	}
+
+	packfile, refUpdate, prHash, githubToken, err := ExtractPackfile(body)
+	if err != nil {
+		return "", "", "", "", fmt.Errorf("failed to extract packfile: %v", err)
+	}
+
+	token := strings.TrimSpace(tokenOverride)
 	if token == "" {
-		return "", "", "", fmt.Errorf("%s not set", tokenEnvVar)
+		token = githubToken
+	}
+	if token == "" {
+		token = os.Getenv(tokenEnvVar)
+	}
+	if token == "" {
+		return "", "", "", "", fmt.Errorf("%s not set", tokenEnvVar)
 	}
 
 	repoURL := cloneURL
 	debugf("DEBUG: Cloning %s/%s...\n", owner, repo)
 
-	_, err := git.PlainClone(tempDir, false, &git.CloneOptions{
+	_, err = git.PlainClone(tempDir, false, &git.CloneOptions{
 		URL: repoURL,
 		Auth: &http.BasicAuth{
 			Username: "x-access-token",
@@ -158,29 +188,20 @@ func ReceivePack(tempDir string, body []byte, owner string, repo string, cloneUR
 		debugf("DEBUG: Clone failed, initializing empty repo: %v\n", err)
 		_, err = git.PlainInit(tempDir, false)
 		if err != nil {
-			return "", "", "", fmt.Errorf("failed to init repo: %v", err)
+			return "", "", "", "", fmt.Errorf("failed to init repo: %v", err)
 		}
 	}
 
 	packDir := tempDir + "/.git/objects/pack"
 	if err := os.MkdirAll(packDir, 0755); err != nil {
-		return "", "", "", fmt.Errorf("failed to create pack dir: %v", err)
-	}
-
-	if len(body) == 0 {
-		return "", "", "", nil
+		return "", "", "", "", fmt.Errorf("failed to create pack dir: %v", err)
 	}
 
 	debugf("DEBUG: Body length: %d bytes\n", len(body))
 	debugf("DEBUG: First 100 bytes: %x\n", body[:min(100, len(body))])
 
-	packfile, refUpdate, prHash, err := ExtractPackfile(body)
-	if err != nil {
-		return "", "", "", fmt.Errorf("failed to extract packfile: %v", err)
-	}
-
 	if refUpdate == nil {
-		return "", "", "", fmt.Errorf("no ref update found in request")
+		return "", "", "", "", fmt.Errorf("no ref update found in request")
 	}
 
 	debugf("DEBUG: Target SHA: %s\n", refUpdate.NewSHA)
@@ -190,7 +211,7 @@ func ReceivePack(tempDir string, body []byte, owner string, repo string, cloneUR
 	packfilePath := tempDir + "/pack.tmp"
 	err = os.WriteFile(packfilePath, packfile, 0644)
 	if err != nil {
-		return "", "", "", fmt.Errorf("failed to write packfile: %v", err)
+		return "", "", "", "", fmt.Errorf("failed to write packfile: %v", err)
 	}
 
 	cmd := exec.Command("git", "index-pack", "-v", "--stdin", "--fix-thin")
@@ -210,38 +231,38 @@ func ReceivePack(tempDir string, body []byte, owner string, repo string, cloneUR
 		debugf("DEBUG: git unpack-objects output: %s\n", string(output))
 
 		if err != nil {
-			return "", "", "", fmt.Errorf("failed to unpack objects: %v\nOutput: %s", err, string(output))
+			return "", "", "", "", fmt.Errorf("failed to unpack objects: %v\nOutput: %s", err, string(output))
 		}
 	}
 
 	r, err := git.PlainOpen(tempDir)
 	if err != nil {
-		return "", "", "", fmt.Errorf("failed to open repo: %v", err)
+		return "", "", "", "", fmt.Errorf("failed to open repo: %v", err)
 	}
 
 	newHash := plumbing.NewHash(refUpdate.NewSHA)
 	ref := plumbing.NewHashReference(plumbing.HEAD, newHash)
 	err = r.Storer.SetReference(ref)
 	if err != nil {
-		return "", "", "", fmt.Errorf("failed to update HEAD: %v", err)
+		return "", "", "", "", fmt.Errorf("failed to update HEAD: %v", err)
 	}
 
 	debugf("DEBUG: Updated HEAD to %s\n", refUpdate.NewSHA)
 
 	originalCommit, err := r.CommitObject(newHash)
 	if err != nil {
-		return "", "", "", fmt.Errorf("failed to get original commit: %v", err)
+		return "", "", "", "", fmt.Errorf("failed to get original commit: %v", err)
 	}
 	commitMessage := originalCommit.Message
 	debugf("DEBUG: Original commit message: %s\n", commitMessage)
 
 	anonymizedSHA, err := AnonymizeCommits(r, refUpdate.NewSHA)
 	if err != nil {
-		return "", "", "", fmt.Errorf("failed to anonymize commits: %v", err)
+		return "", "", "", "", fmt.Errorf("failed to anonymize commits: %v", err)
 	}
 
 	debugf("DEBUG: Anonymized commit: %s\n", anonymizedSHA)
-	return anonymizedSHA, commitMessage, prHash, nil
+	return anonymizedSHA, commitMessage, prHash, githubToken, nil
 }
 
 func resolveBaseReference(r *git.Repository) *plumbing.Reference {

--- a/internal/github/pr.go
+++ b/internal/github/pr.go
@@ -21,6 +21,13 @@ import (
 
 var httpClient = &http.Client{Timeout: 60 * time.Second}
 
+func resolveGitHubToken(token string) string {
+	if strings.TrimSpace(token) != "" {
+		return strings.TrimSpace(token)
+	}
+	return tokenpool.NextGitHubToken()
+}
+
 // githubDo executes a request with the given token and marks the token as
 // rate-limited when GitHub returns 403/429 (rate limit exceeded).
 func githubDo(req *http.Request, token string) (*http.Response, error) {
@@ -285,7 +292,11 @@ func DeleteCommentsByHash(hash string) error {
 }
 
 func CreateAnonymousIssue(owner, repo, title, body string, labels []string) (string, int, error) {
-	token := tokenpool.NextGitHubToken()
+	return CreateAnonymousIssueWithToken(owner, repo, title, body, labels, "")
+}
+
+func CreateAnonymousIssueWithToken(owner, repo, title, body string, labels []string, token string) (string, int, error) {
+	token = resolveGitHubToken(token)
 	if token == "" {
 		return "", 0, fmt.Errorf("GITHUB_TOKEN not set")
 	}
@@ -336,7 +347,11 @@ func CreateAnonymousIssue(owner, repo, title, body string, labels []string) (str
 }
 
 func CreateAnonymousComment(owner, repo string, number int, body string) (string, error) {
-	token := tokenpool.NextGitHubToken()
+	return CreateAnonymousCommentWithToken(owner, repo, number, body, "")
+}
+
+func CreateAnonymousCommentWithToken(owner, repo string, number int, body string, token string) (string, error) {
+	token = resolveGitHubToken(token)
 	if token == "" {
 		return "", fmt.Errorf("GITHUB_TOKEN not set")
 	}
@@ -379,7 +394,11 @@ func CreateAnonymousComment(owner, repo string, number int, body string) (string
 }
 
 func CreateAnonymousPRComment(owner, repo string, number int, body string) (string, error) {
-	token := tokenpool.NextGitHubToken()
+	return CreateAnonymousPRCommentWithToken(owner, repo, number, body, "")
+}
+
+func CreateAnonymousPRCommentWithToken(owner, repo string, number int, body string, token string) (string, error) {
+	token = resolveGitHubToken(token)
 	if token == "" {
 		return "", fmt.Errorf("GITHUB_TOKEN not set")
 	}
@@ -424,7 +443,11 @@ func CreateAnonymousPRComment(owner, repo string, number int, body string) (stri
 }
 
 func CreateAnonymousDiscussionComment(owner, repo string, number int, body string) (string, error) {
-	token := tokenpool.NextGitHubToken()
+	return CreateAnonymousDiscussionCommentWithToken(owner, repo, number, body, "")
+}
+
+func CreateAnonymousDiscussionCommentWithToken(owner, repo string, number int, body string, token string) (string, error) {
+	token = resolveGitHubToken(token)
 	if token == "" {
 		return "", fmt.Errorf("GITHUB_TOKEN not set")
 	}
@@ -535,7 +558,11 @@ func (r *Ref) GetSha() string {
 }
 
 func ForkRepo(owner, repo string) (string, error) {
-	token := tokenpool.NextGitHubToken()
+	return ForkRepoWithToken(owner, repo, "")
+}
+
+func ForkRepoWithToken(owner, repo string, token string) (string, error) {
+	token = resolveGitHubToken(token)
 	if token == "" {
 		return "", fmt.Errorf("GITHUB_TOKEN not set")
 	}
@@ -645,7 +672,11 @@ func ClosePRByURL(prURL string) error {
 }
 
 func CreatePR(owner, repo, branch, forkOwner, commitMessage string) (string, error) {
-	token := tokenpool.NextGitHubToken()
+	return CreatePRWithToken(owner, repo, branch, forkOwner, commitMessage, "")
+}
+
+func CreatePRWithToken(owner, repo, branch, forkOwner, commitMessage, token string) (string, error) {
+	token = resolveGitHubToken(token)
 	if token == "" {
 		return "", fmt.Errorf("GITHUB_TOKEN not set")
 	}

--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -400,7 +400,7 @@ func ReceivePackHandler(c *gin.Context) {
 
 	WriteSidebandLine(&response, 2, "remote: gitGost: Processing your anonymous contribution...")
 
-	newSHA, commitMessage, receivedPRHash, err := git.ReceivePack(tempDir, body, owner, repo, prov.CloneURL(owner, repo), prov.TokenEnvVar())
+	newSHA, commitMessage, receivedPRHash, githubToken, err := git.ReceivePack(tempDir, body, owner, repo, prov.CloneURL(owner, repo), prov.TokenEnvVar(), "")
 	if err != nil {
 		utils.Log("Error receiving pack: %v", err)
 		WriteSidebandLine(&response, 3, fmt.Sprintf("unpack error: %v", err))
@@ -413,7 +413,14 @@ func ReceivePackHandler(c *gin.Context) {
 	WriteSidebandLine(&response, 2, "remote: gitGost: Commits anonymized successfully")
 
 	WriteSidebandLine(&response, 2, "remote: gitGost: Creating fork...")
-	forkOwner, err := prov.ForkRepo(owner, repo)
+	forkOwner, err := func() (string, error) {
+		if githubToken != "" {
+			if _, ok := prov.(*ghprovider.GitHubProvider); ok {
+				return github.ForkRepoWithToken(owner, repo, githubToken)
+			}
+		}
+		return prov.ForkRepo(owner, repo)
+	}()
 	if err != nil {
 		utils.Log("Error creating fork: %v", err)
 		WriteSidebandLine(&response, 1, "unpack ok\n")
@@ -440,7 +447,7 @@ func ReceivePackHandler(c *gin.Context) {
 
 		if branchExists {
 			WriteSidebandLine(&response, 2, "remote: gitGost: Pushing update to existing branch...")
-			branch, err = git.PushToGitHub(owner, repo, tempDir, forkOwner, branchFromHash, prov.PushURL(forkOwner, repo), prov.TokenEnvVar())
+			branch, err = git.PushToGitHub(owner, repo, tempDir, forkOwner, branchFromHash, prov.PushURL(forkOwner, repo), prov.TokenEnvVar(), githubToken)
 			if err != nil {
 				utils.Log("Error pushing update to fork: %v", err)
 				WriteSidebandLine(&response, 1, "unpack ok\n")
@@ -455,7 +462,15 @@ func ReceivePackHandler(c *gin.Context) {
 				utils.Log("Updated existing branch: %s, PR: %s", branch, prURL)
 			} else {
 				WriteSidebandLine(&response, 2, "remote: gitGost: PR was closed, creating new PR on existing branch...")
-				prURL, err = prov.CreateMR(owner, repo, branch, forkOwner, commitMessage)
+				if githubToken != "" {
+					if _, ok := prov.(*ghprovider.GitHubProvider); ok {
+						prURL, err = github.CreatePRWithToken(owner, repo, branch, forkOwner, commitMessage, githubToken)
+					} else {
+						prURL, err = prov.CreateMR(owner, repo, branch, forkOwner, commitMessage)
+					}
+				} else {
+					prURL, err = prov.CreateMR(owner, repo, branch, forkOwner, commitMessage)
+				}
 				if err != nil {
 					utils.Log("Error creating PR on existing branch: %v", err)
 					WriteSidebandLine(&response, 1, "unpack ok\n")
@@ -478,7 +493,7 @@ func ReceivePackHandler(c *gin.Context) {
 
 	if !isUpdate {
 		WriteSidebandLine(&response, 2, "remote: gitGost: Pushing to fork...")
-		branch, err = git.PushToGitHub(owner, repo, tempDir, forkOwner, "", prov.PushURL(forkOwner, repo), prov.TokenEnvVar())
+		branch, err = git.PushToGitHub(owner, repo, tempDir, forkOwner, "", prov.PushURL(forkOwner, repo), prov.TokenEnvVar(), githubToken)
 		if err != nil {
 			utils.Log("Error pushing to fork: %v", err)
 			WriteSidebandLine(&response, 1, "unpack ok\n")
@@ -492,7 +507,15 @@ func ReceivePackHandler(c *gin.Context) {
 		WriteSidebandLine(&response, 2, fmt.Sprintf("remote: gitGost: Branch '%s' created", branch))
 
 		WriteSidebandLine(&response, 2, "remote: gitGost: Creating pull request...")
-		prURL, err = prov.CreateMR(owner, repo, branch, forkOwner, commitMessage)
+		if githubToken != "" {
+			if _, ok := prov.(*ghprovider.GitHubProvider); ok {
+				prURL, err = github.CreatePRWithToken(owner, repo, branch, forkOwner, commitMessage, githubToken)
+			} else {
+				prURL, err = prov.CreateMR(owner, repo, branch, forkOwner, commitMessage)
+			}
+		} else {
+			prURL, err = prov.CreateMR(owner, repo, branch, forkOwner, commitMessage)
+		}
 		if err != nil {
 			utils.Log("Error creating PR: %v", err)
 			WriteSidebandLine(&response, 1, "unpack ok\n")
@@ -813,11 +836,13 @@ type anonymousIssueRequest struct {
 	Title        string   `json:"title"`
 	Body         string   `json:"body"`
 	Labels       []string `json:"labels"`
+	GitHubToken  string   `json:"github_token"`
 	CaptchaToken string   `json:"captcha_token"`
 }
 
 type anonymousCommentRequest struct {
 	UserToken    string `json:"user_token"`
+	GitHubToken  string `json:"github_token"`
 	Body         string `json:"body"`
 	CaptchaToken string `json:"captcha_token"`
 }
@@ -1297,6 +1322,31 @@ func CreateAnonymousIssueHandler(c *gin.Context) {
 	}
 
 	prov := providerFromPath(c.Request.URL.Path)
+	if req.GitHubToken != "" {
+		if _, ok := prov.(*ghprovider.GitHubProvider); ok {
+			issueURL, issueNumber, err := github.CreateAnonymousIssueWithToken(owner, repo, req.Title, req.Body, req.Labels, req.GitHubToken)
+			if err != nil {
+				utils.Log("Error creating issue: %v", err)
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
+			}
+			userToken := generateUserToken()
+			hash := deriveHash(owner, repo, issueNumber, userToken)
+			karma := getKarma(c.Request.Context(), hash)
+			updateKarma(c.Request.Context(), hash, karma)
+			resp := gin.H{
+				"issue_url":         issueURL,
+				"number":            issueNumber,
+				"hash":              hash,
+				"karma":             karma,
+				"user_token":        userToken,
+				"issue_reply_token": userToken,
+				"appeal_token":      generateAppealToken(hash),
+			}
+			c.JSON(http.StatusOK, resp)
+			return
+		}
+	}
 	issueURL, issueNumber, err := prov.CreateAnonymousIssue(owner, repo, req.Title, req.Body, req.Labels)
 	if err != nil {
 		utils.Log("Error creating issue: %v", err)
@@ -2018,6 +2068,29 @@ func CreateAnonymousCommentHandler(c *gin.Context) {
 	bodyWithLegend := req.Body + legend
 
 	prov := providerFromPath(c.Request.URL.Path)
+	if req.GitHubToken != "" {
+		if _, ok := prov.(*ghprovider.GitHubProvider); ok {
+			commentURL, err := github.CreateAnonymousCommentWithToken(owner, repo, number, bodyWithLegend, req.GitHubToken)
+			if err != nil {
+				utils.Log("Error creating comment: %v", err)
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
+			}
+			if dbClient != nil {
+				if err := dbClient.InsertComment(c.Request.Context(), owner, repo, commentURL); err != nil {
+					utils.Log("Error recording comment in DB: %v", err)
+				}
+			}
+			c.JSON(http.StatusOK, gin.H{
+				"comment_url":  commentURL,
+				"hash":         hash,
+				"karma":        karma,
+				"user_token":   userToken,
+				"appeal_token": generateAppealToken(hash),
+			})
+			return
+		}
+	}
 	commentURL, err := prov.CreateAnonymousComment(owner, repo, number, bodyWithLegend)
 	if err != nil {
 		utils.Log("Error creating comment: %v", err)
@@ -2102,6 +2175,29 @@ func CreateAnonymousPRCommentHandler(c *gin.Context) {
 	bodyWithLegend := req.Body + legend
 
 	prov := providerFromPath(c.Request.URL.Path)
+	if req.GitHubToken != "" {
+		if _, ok := prov.(*ghprovider.GitHubProvider); ok {
+			commentURL, err := github.CreateAnonymousPRCommentWithToken(owner, repo, number, bodyWithLegend, req.GitHubToken)
+			if err != nil {
+				utils.Log("Error creating PR comment: %v", err)
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
+			}
+			if dbClient != nil {
+				if err := dbClient.InsertComment(c.Request.Context(), owner, repo, commentURL); err != nil {
+					utils.Log("Error recording PR comment in DB: %v", err)
+				}
+			}
+			c.JSON(http.StatusOK, gin.H{
+				"comment_url":  commentURL,
+				"hash":         hash,
+				"karma":        karma,
+				"user_token":   userToken,
+				"appeal_token": generateAppealToken(hash),
+			})
+			return
+		}
+	}
 	commentURL, err := prov.CreateAnonymousPRComment(owner, repo, number, bodyWithLegend)
 	if err != nil {
 		utils.Log("Error creating PR comment: %v", err)
@@ -2181,6 +2277,29 @@ func CreateAnonymousDiscussionCommentHandler(c *gin.Context) {
 	bodyWithLegend := req.Body + legend
 
 	prov := providerFromPath(c.Request.URL.Path)
+	if req.GitHubToken != "" {
+		if _, ok := prov.(*ghprovider.GitHubProvider); ok {
+			commentURL, err := github.CreateAnonymousDiscussionCommentWithToken(owner, repo, number, bodyWithLegend, req.GitHubToken)
+			if err != nil {
+				utils.Log("Error creating discussion comment: %v", err)
+				c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+				return
+			}
+			if dbClient != nil {
+				if err := dbClient.InsertComment(c.Request.Context(), owner, repo, commentURL); err != nil {
+					utils.Log("Error recording discussion comment in DB: %v", err)
+				}
+			}
+			c.JSON(http.StatusOK, gin.H{
+				"comment_url":  commentURL,
+				"hash":         hash,
+				"karma":        karma,
+				"user_token":   userToken,
+				"appeal_token": generateAppealToken(hash),
+			})
+			return
+		}
+	}
 	commentURL, err := prov.CreateAnonymousDiscussionComment(owner, repo, number, bodyWithLegend)
 	if err != nil {
 		utils.Log("Error creating discussion comment: %v", err)

--- a/web/index.html
+++ b/web/index.html
@@ -1705,6 +1705,10 @@
 		<path d="M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2" />
 	</g>
 </svg> git extension</a>
+                <a href="#" onclick="showPage('settings'); return false;" class="nav-link"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24">
+	<path d="M0 0h24v24H0z" fill="none" />
+	<path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M7.05 6.462a2 2 0 0 0 2.63-1.519l.32-1.72a9 9 0 0 1 3.998 0l.322 1.72a2 2 0 0 0 2.63 1.519l1.649-.58a9 9 0 0 1 2.001 3.46l-1.33 1.14a2 2 0 0 0 0 3.037l1.33 1.139a9 9 0 0 1-2.001 3.46l-1.65-.58a2 2 0 0 0-2.63 1.519L14 20.777a9 9 0 0 1-3.998 0l-.322-1.72a2 2 0 0 0-2.63-1.519l-1.649.58a9 9 0 0 1-2.001-3.46l1.33-1.14a2 2 0 0 0 0-3.036L3.4 9.342a9 9 0 0 1 2-3.46zM12 9a3 3 0 1 1 0 6a3 3 0 0 1 0-6" clip-rule="evenodd" />
+                </svg> settings</a>
                 <div style="font-family:'IBM Plex Mono',monospace;font-size:0.68rem;color:var(--fg-secondary);text-transform:uppercase;letter-spacing:0.06em;margin:1.5rem 0 0.5rem;">create a</div>
                 <a href="#" onclick="showPage('issue'); return false;" class="nav-link" style="padding-left:1rem;"><svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24">
 	<path d="M0 0h24v24H0z" fill="none" />
@@ -2324,12 +2328,12 @@
                             <span class="prompt">$</span> git config --global
                             https.proxy socks5://127.0.0.1:9050
                             <span class="comment"
-                                ># Luego haz push normalmente a través de
+                                ># Then push normally through
                                 gitGost</span
                             >
                             <span class="prompt">$</span> git push gost
                             fix-typo:main <span class="success">→</span> Push
-                            enrutado a través de Tor + anonimización gitGost
+                            routed through Tor + gitGost anonymization
                         </div>
                     </div>
                 </div>
@@ -2501,11 +2505,11 @@
                         "
                     >
                         <p>
-                            <strong>Contenido prohibido:</strong> sin enlaces,
-                            issues o comentarios que involucren religión,
-                            violencia, espiritismo, inmoralidad sexual, alcohol,
-                            drogas, armas, pornografía o profanidad. El
-                            contenido detectado será eliminado.
+                            <strong>Prohibited content:</strong> no links,
+                            issues or comments involving religion, violence,
+                            occultism, sexual immorality, alcohol, drugs,
+                            weapons, pornography, or profanity. Detected
+                            content will be removed.
                         </p>
                     </div>
                     <div
@@ -2674,7 +2678,7 @@
                         </div>
                     </div>
                     <div class="form-group">
-                        <label for="comment-number">Número de Issue</label>
+                        <label for="comment-number">Issue number</label>
                         <input id="comment-number" type="number" min="1" placeholder="123" autocomplete="off" />
                     </div>
                     <div class="form-group">
@@ -2718,7 +2722,7 @@
                         </div>
                     </div>
                     <div class="form-group">
-                        <label for="pr-number" id="pr-number-label">Número de Pull Request</label>
+                        <label for="pr-number" id="pr-number-label">Pull Request number</label>
                         <input id="pr-number" type="number" min="1" placeholder="42" autocomplete="off" />
                     </div>
                     <div class="form-group">
@@ -3959,12 +3963,15 @@
                                         <button class="terminal-tab" data-push-provider="gl" style="font-size:0.8rem;padding:0.35rem 0.75rem;">GitLab</button>
                                         <button class="terminal-tab" data-push-provider="cb" style="font-size:0.8rem;padding:0.35rem 0.75rem;">Codeberg</button>
                                     </div>
-                                    <div class="terminal-body" id="push-body-gh"><span class="comment"># Add as remote → push → done. Fully anonymous.</span>
+                                    <div class="terminal-body" id="push-body-gh"><span class="comment"># Anonymous by default. Add -o github-token=... to use your own GitHub service account.</span>
 <span class="prompt">$</span> git remote add gost https://gitgost.fly.dev/v1/gh/torvalds/linux
 <span class="prompt">$</span> git checkout -b fix-typo
 <span class="prompt">$</span> git commit -am "fix: typo in documentation"
 <span class="prompt">$</span> git push gost fix-typo:main
 <span class="success">→</span> Anonymized commit + PR opened as @gitgost-anonymous
+<span class="comment"># Or, with your own account:</span>
+<span class="prompt">$</span> git push gost fix-typo:main -o github-token=ghp_xxxxxxxxxxxx
+<span class="success">→</span> Anonymized commit + PR opened with your GitHub account
 <span class="success">→</span> PR Hash: <span class="hl">a3f8c1d2</span> ← save this to update the PR later</div>
                                     <div class="terminal-body" id="push-body-gl" style="display:none;"><span class="comment"># Use /v1/gl/ instead of /v1/gh/ for GitLab repos.</span>
 <span class="prompt">$</span> git remote add gost https://gitgost.fly.dev/v1/gl/gitlab-org/gitlab
@@ -3991,7 +3998,7 @@
                                 <div style="display:flex;align-items:baseline;gap:0.75rem;margin-bottom:0.6rem;">
                                     <code style="font-family:'IBM Plex Mono',monospace;font-size:0.72rem;background:var(--accent);color:#fff;border-radius:3px;padding:0.15em 0.5em;">POST</code>
                                     <span style="font-family:'IBM Plex Mono',monospace;font-size:0.88rem;color:var(--fg);font-weight:600;">update PR</span>
-                                    <span style="font-size:0.75rem;color:var(--fg-secondary);">— push follow-up commit to existing PR</span>
+                                    <span style="font-size:0.75rem;color:var(--fg-secondary);">— push a follow-up commit to an existing PR</span>
                                 </div>
                                 <div class="terminal">
                                     <div class="terminal-titlebar">
@@ -3999,11 +4006,11 @@
                                         <span class="terminal-btn min"></span>
                                         <span class="terminal-btn max"></span>
                                     </div>
-                                    <div class="terminal-body"><span class="comment"># Use the pr-hash returned on first push</span>
+                                    <div class="terminal-body"><span class="comment"># Reuse the pr-hash returned by the first push.</span>
 <span class="prompt">$</span> git commit -am "fix: address review comments"
 <span class="prompt">$</span> git push gost fix-typo:main -o pr-hash=<span class="hl">a3f8c1d2</span>
 <span class="success">→</span> Existing branch force-updated, PR refreshed — still @gitgost-anonymous
-<span class="comment"># If hash unknown or PR closed, a new PR is created automatically.</span></div>
+<span class="comment"># If the hash is unknown or the PR was closed, gitGost creates a new PR automatically.</span></div>
                                 </div>
                             </div>
 
@@ -4231,12 +4238,48 @@
                                     </div>
                                     <div style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:var(--radius-md);padding:1.25rem;">
                                         <div style="font-family:'IBM Plex Mono',monospace;font-size:0.68rem;color:var(--accent);text-transform:uppercase;letter-spacing:0.06em;margin-bottom:0.5rem;">Open source</div>
-                                        <h3 style="margin:0 0 0.5rem;font-size:0.95rem;color:var(--fg);">Auditable and verifiable</h3>
+                                        <h3 style="margin:0 0 0.5rem;font-size:0.95rem;color:var(--fg);">Auditable and copyleft</h3>
                                         <p style="margin:0;font-size:0.78rem;color:var(--fg-muted);">AGPL-3.0 licensed. The job queue is local to your machine and every binary ships with SHA-256 and Sigstore attestation.</p>
                                     </div>
                                 </div>
                             </div>
 
+                        </div>`
+                },
+                settings: {
+                    title: 'Account Settings',
+                    html: () => `
+                        <div style="display:flex;flex-direction:column;gap:1rem;max-width:640px;">
+                            <div style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:var(--radius-md);padding:1rem 1.1rem;">
+                                <p style="margin:0;font-size:0.82rem;color:var(--fg-muted);line-height:1.6;">Saving your token here lets gitGost use your own anonymous GitHub account for issues, comments, and pushes. The token stays in this browser and is sent to the backend only when you choose to use it.</p>
+                            </div>
+                            <div class="form-group" style="margin-bottom:0;">
+                                <label for="gh-token-input">GitHub token</label>
+                                <input id="gh-token-input" type="password" placeholder="ghp_..." autocomplete="off" />
+                            </div>
+                            <div class="form-actions" style="margin-bottom:0;">
+                                <button class="btn primary" id="gh-token-save" type="button">Save token</button>
+                                <button class="btn" id="gh-token-clear" type="button">Clear token</button>
+                                <span class="form-status" id="gh-token-status"></span>
+                            </div>
+                            <div class="form-note"><p>Used by GitHub when your own account is saved. It does not affect GitLab or Codeberg.</p></div>
+                        </div>`
+                },
+                faq: {
+                    title: 'Comment Approach',
+                    html: () => `
+                        <p style="color:var(--fg-secondary);margin-bottom:1rem;">How we keep anonymous conversations useful.</p>
+                        <div style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:var(--radius-md);padding:1.25rem 1.4rem;margin-bottom:1rem;">
+                            <p>gitGost allows anonymous contributions, but we work to keep conversations useful. This is a deliberate effort to prevent anonymity from degrading quality.</p>
+                            <p><strong>Prohibited content:</strong> no links, issues or comments involving religion, violence, occultism, sexual immorality, alcohol, drugs, weapons, pornography or profanity. Detected content will be removed.</p>
+                            <ul style="margin:0.4rem 0 1rem 1.2rem;padding:0;">
+                                <li>Don't submit or upvote empty links. We want material that teaches something real, not shallow curiosity.</li>
+                                <li>"Genuinely interesting" means it leaves learning or context. Avoid gossip, flamebait or empty politics.</li>
+                                <li>Key principle: thoughtful comments. Civility + substance. Does your comment add new context or personal experience?</li>
+                                <li>Empty negative comments (just insults) don't help; a brief "thanks" does.</li>
+                                <li>Rule of thumb: don't write what you wouldn't say face to face. Debate is welcome; insults are not.</li>
+                            </ul>
+                            <p style="color:var(--fg-secondary);">If you're right, your arguments stand without put-downs. Curiosity beats noise.</p>
                         </div>`
                 },
                 issue: {
@@ -4477,7 +4520,7 @@
                                 <div style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:var(--radius-md);padding:1.25rem;">
                                     <div style="font-family:'IBM Plex Mono',monospace;font-size:0.68rem;color:var(--accent);text-transform:uppercase;letter-spacing:0.06em;margin-bottom:0.5rem;">No Accounts</div>
                                     <h3 style="margin:0 0 0.5rem;font-size:0.95rem;color:var(--fg);">Zero signup required</h3>
-                                    <p style="margin:0;font-size:0.78rem;color:var(--fg-muted);">No tokens, logins, or browser extensions. Just add a remote and push like you always do.</p>
+                                    <p style="margin:0;font-size:0.78rem;color:var(--fg-muted);">No tokens or logins by default. If you choose to connect your own account, it stays in this browser until you clear it.</p>
                                 </div>
                                 <div style="background:var(--bg-secondary);border:1px solid var(--border);border-radius:var(--radius-md);padding:1.25rem;">
                                     <div style="font-family:'IBM Plex Mono',monospace;font-size:0.68rem;color:var(--accent);text-transform:uppercase;letter-spacing:0.06em;margin-bottom:0.5rem;">Open Source</div>
@@ -4518,7 +4561,7 @@
                                 <h3 style="margin-top:0;color:var(--accent);">What we don't keep</h3>
                                 <ul style="margin:0.4rem 0 0 1.2rem;padding:0;font-size:0.82rem;color:var(--fg-muted);">
                                     <li>No commits, blobs, or refs after forwarding.</li>
-                                    <li>No GitHub tokens or access keys.</li>
+                                    <li>No GitHub tokens or access keys unless you explicitly save one in settings.</li>
                                     <li>No IP addresses or session histories.</li>
                                     <li>No names, emails, or SSH fingerprints.</li>
                                     <li>No persistent request logs.</li>
@@ -4637,7 +4680,7 @@
                 if (prProvider) {
                     prProvider.addEventListener('change', () => {
                         const label = pageContent.querySelector('#pr-number-label');
-                        if (label) label.textContent = prProvider.value === 'gl' ? 'Número de Merge Request' : 'Número de Pull Request';
+                        if (label) label.textContent = prProvider.value === 'gl' ? 'Merge Request number' : 'Pull Request number';
                     });
                 }
 
@@ -4653,6 +4696,32 @@
             }
 
             function bindFormHandlers(root) {
+                const ghTokenInput = root.querySelector('#gh-token-input');
+                const ghTokenSave = root.querySelector('#gh-token-save');
+                const ghTokenClear = root.querySelector('#gh-token-clear');
+                const ghTokenStatus = root.querySelector('#gh-token-status');
+                if (ghTokenInput) {
+                    ghTokenInput.value = localStorage.getItem('gh_token') || '';
+                }
+                if (ghTokenSave) {
+                    ghTokenSave.addEventListener('click', () => {
+                        const value = (ghTokenInput?.value || '').trim();
+                        if (value) {
+                            localStorage.setItem('gh_token', value);
+                            if (ghTokenStatus) ghTokenStatus.textContent = 'Saved';
+                        } else {
+                            localStorage.removeItem('gh_token');
+                            if (ghTokenStatus) ghTokenStatus.textContent = 'Cleared';
+                        }
+                    });
+                }
+                if (ghTokenClear) {
+                    ghTokenClear.addEventListener('click', () => {
+                        localStorage.removeItem('gh_token');
+                        if (ghTokenInput) ghTokenInput.value = '';
+                        if (ghTokenStatus) ghTokenStatus.textContent = 'Cleared';
+                    });
+                }
                 let issueTemplates = [];
                         const issueSubmit = root.querySelector('#issue-submit');
                 if (issueSubmit) {
@@ -4704,26 +4773,29 @@
                                 if (bodyEl) bodyEl.value = body;
                             }
                         }
-                        if (!title || !body) { if (statusEl) statusEl.textContent = 'Campos requeridos'; return; }
+                        if (!title || !body) { if (statusEl) statusEl.textContent = 'Required fields'; return; }
                         const labels = labelsRaw ? labelsRaw.split(',').map(l => l.trim()).filter(Boolean) : [];
                         issueSubmit.disabled = true;
-                        if (statusEl) statusEl.textContent = 'Enviando...';
+                        if (statusEl) statusEl.textContent = 'Sending...';
                         if (resultEl) resultEl.textContent = '';
+                        const githubToken = provider === 'gh' ? (localStorage.getItem('gh_token') || '').trim() : '';
+                        const payload = { title, body, labels };
+                        if (githubToken) payload.github_token = githubToken;
                         try {
                             const res = await fetch(`/v1/${provider}/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues/anonymous`, {
                                 method: 'POST', headers: { 'Content-Type': 'application/json', 'X-Gitgost-Key': 'gitgost-anonymous' },
-                                body: JSON.stringify({ title, body, labels }),
+                                body: JSON.stringify(payload),
                             });
                             if (!res.ok) throw new Error(`HTTP ${res.status}`);
                             const data = await res.json();
-                            if (statusEl) statusEl.textContent = 'Creado';
+                            if (statusEl) statusEl.textContent = 'Created';
                             const parts = [];
                             if (data.issue_url) parts.push(`Issue: ${data.issue_url}`);
                             if (data.hash) parts.push(`Hash: ${data.hash}`);
                             if (data.karma !== undefined) parts.push(`Karma: ${data.karma}`);
                             if (data.user_token) parts.push(`Token: ${data.user_token}`);
                             if (resultEl) resultEl.textContent = parts.join(' · ');
-                        } catch { if (statusEl) statusEl.textContent = 'Error'; if (resultEl) resultEl.textContent = 'No se pudo crear.'; }
+                        } catch { if (statusEl) statusEl.textContent = 'Error'; if (resultEl) resultEl.textContent = 'Could not create it.'; }
                         finally { issueSubmit.disabled = false; }
                     });
                 }
@@ -4739,12 +4811,14 @@
                         const body = root.querySelector('#comment-body')?.value.trim();
                         const statusEl = root.querySelector('#comment-status');
                         const resultEl = root.querySelector('#comment-result');
-                        if (!owner || !repo || !number || !body) { if (statusEl) statusEl.textContent = 'Campos requeridos'; return; }
+                        if (!owner || !repo || !number || !body) { if (statusEl) statusEl.textContent = 'Required fields'; return; }
                         commentSubmit.disabled = true;
-                        if (statusEl) statusEl.textContent = 'Enviando...';
+                        if (statusEl) statusEl.textContent = 'Sending...';
                         if (resultEl) resultEl.textContent = '';
+                        const githubToken = provider === 'gh' ? (localStorage.getItem('gh_token') || '').trim() : '';
                         const payload = { body };
                         if (token) payload.user_token = token;
+                        if (githubToken) payload.github_token = githubToken;
                         try {
                             const res = await fetch(`/v1/${provider}/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues/${encodeURIComponent(number)}/comments/anonymous`, {
                                 method: 'POST', headers: { 'Content-Type': 'application/json', 'X-Gitgost-Key': 'gitgost-anonymous' },
@@ -4752,7 +4826,7 @@
                             });
                             if (!res.ok) throw new Error(`HTTP ${res.status}`);
                             const data = await res.json();
-                            if (statusEl) statusEl.textContent = 'Enviado';
+                            if (statusEl) statusEl.textContent = 'Sent';
                             const parts = [];
                             if (data.hash) parts.push(`Hash: ${data.hash}`);
                             if (data.karma !== undefined) parts.push(`Karma: ${data.karma}`);
@@ -4774,12 +4848,14 @@
                         const body = root.querySelector('#pr-comment-body')?.value.trim();
                         const statusEl = root.querySelector('#pr-comment-status');
                         const resultEl = root.querySelector('#pr-comment-result');
-                        if (!owner || !repo || !number || !body) { if (statusEl) statusEl.textContent = 'Campos requeridos'; return; }
+                        if (!owner || !repo || !number || !body) { if (statusEl) statusEl.textContent = 'Required fields'; return; }
                         prCommentSubmit.disabled = true;
-                        if (statusEl) statusEl.textContent = 'Enviando...';
+                        if (statusEl) statusEl.textContent = 'Sending...';
                         if (resultEl) resultEl.textContent = '';
+                        const githubToken = provider === 'gh' ? (localStorage.getItem('gh_token') || '').trim() : '';
                         const payload = { body };
                         if (token) payload.user_token = token;
+                        if (githubToken) payload.github_token = githubToken;
                         try {
                             const res = await fetch(`/v1/${provider}/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls/${encodeURIComponent(number)}/comments/anonymous`, {
                                 method: 'POST', headers: { 'Content-Type': 'application/json', 'X-Gitgost-Key': 'gitgost-anonymous' },
@@ -4787,14 +4863,14 @@
                             });
                             if (!res.ok) throw new Error(`HTTP ${res.status}`);
                             const data = await res.json();
-                            if (statusEl) statusEl.textContent = 'Enviado';
+                            if (statusEl) statusEl.textContent = 'Sent';
                             const parts = [];
-                            if (data.comment_url) parts.push(`Comentario: ${data.comment_url}`);
+                            if (data.comment_url) parts.push(`Comment: ${data.comment_url}`);
                             if (data.hash) parts.push(`Hash: ${data.hash}`);
                             if (data.karma !== undefined) parts.push(`Karma: ${data.karma}`);
                             if (data.user_token && !token) parts.push(`Token: ${data.user_token}`);
                             if (resultEl) resultEl.textContent = parts.join(' · ');
-                        } catch { if (statusEl) statusEl.textContent = 'Error'; if (resultEl) resultEl.textContent = 'No se pudo enviar.'; }
+                        } catch { if (statusEl) statusEl.textContent = 'Error'; if (resultEl) resultEl.textContent = 'Could not send it.'; }
                         finally { prCommentSubmit.disabled = false; }
                     });
                 }
@@ -4990,11 +5066,11 @@
                 const resultEl = document.getElementById('issue-result');
                 const btn = document.getElementById('issue-submit');
 
-                if (!owner || !repo || !title || !body) { if (statusEl) statusEl.textContent = 'Campos requeridos'; return; }
+                if (!owner || !repo || !title || !body) { if (statusEl) statusEl.textContent = 'Required fields'; return; }
 
                 const labels = labelsRaw ? labelsRaw.split(',').map(l => l.trim()).filter(Boolean) : [];
                 if (btn) btn.disabled = true;
-                if (statusEl) statusEl.textContent = 'Enviando...';
+                if (statusEl) statusEl.textContent = 'Sending...';
                 if (resultEl) resultEl.textContent = '';
 
                 try {
@@ -5005,7 +5081,7 @@
                     });
                     if (!res.ok) throw new Error(`HTTP ${res.status}`);
                     const data = await res.json();
-                    if (statusEl) statusEl.textContent = 'Creado';
+                    if (statusEl) statusEl.textContent = 'Created';
                     const parts = [];
                     if (data.issue_url) parts.push(`Issue: ${data.issue_url}`);
                     if (data.hash) parts.push(`Hash: ${data.hash}`);
@@ -5014,7 +5090,7 @@
                     if (resultEl) resultEl.textContent = parts.join(' · ');
                 } catch (e) {
                     if (statusEl) statusEl.textContent = 'Error';
-                    if (resultEl) resultEl.textContent = 'No se pudo crear. Verifica owner/repo y que los issues estén habilitados.';
+                    if (resultEl) resultEl.textContent = 'Could not create it. Check owner/repo and whether issues are enabled.';
                 } finally {
                     if (btn) btn.disabled = false;
                 }
@@ -5031,10 +5107,10 @@
                 const resultEl = document.getElementById('comment-result');
                 const btn = document.getElementById('comment-submit');
 
-                if (!owner || !repo || !number || !body) { if (statusEl) statusEl.textContent = 'Campos requeridos'; return; }
+                if (!owner || !repo || !number || !body) { if (statusEl) statusEl.textContent = 'Required fields'; return; }
 
                 if (btn) btn.disabled = true;
-                if (statusEl) statusEl.textContent = 'Enviando...';
+                if (statusEl) statusEl.textContent = 'Sending...';
                 if (resultEl) resultEl.textContent = '';
 
                 const payload = { body };
@@ -5048,7 +5124,7 @@
                     });
                     if (!res.ok) throw new Error(`HTTP ${res.status}`);
                     const data = await res.json();
-                    if (statusEl) statusEl.textContent = 'Enviado';
+                    if (statusEl) statusEl.textContent = 'Sent';
                     const parts = [];
                     if (data.hash) parts.push(`Hash: ${data.hash}`);
                     if (data.karma !== undefined) parts.push(`Karma: ${data.karma}`);
@@ -5056,7 +5132,7 @@
                     if (resultEl) resultEl.textContent = parts.join(' · ');
                 } catch (e) {
                     if (statusEl) statusEl.textContent = 'Error';
-                    if (resultEl) resultEl.textContent = 'No se pudo enviar. Verifica el número de issue y permisos.';
+                    if (resultEl) resultEl.textContent = 'Could not send it. Check the issue number and permissions.';
                 } finally {
                     if (btn) btn.disabled = false;
                 }
@@ -5073,10 +5149,10 @@
                 const resultEl = document.getElementById('pr-comment-result');
                 const btn = document.getElementById('pr-comment-submit');
 
-                if (!owner || !repo || !number || !body) { if (statusEl) statusEl.textContent = 'Campos requeridos'; return; }
+                if (!owner || !repo || !number || !body) { if (statusEl) statusEl.textContent = 'Required fields'; return; }
 
                 if (btn) btn.disabled = true;
-                if (statusEl) statusEl.textContent = 'Enviando...';
+                if (statusEl) statusEl.textContent = 'Sending...';
                 if (resultEl) resultEl.textContent = '';
 
                 const payload = { body };
@@ -5090,16 +5166,16 @@
                     });
                     if (!res.ok) throw new Error(`HTTP ${res.status}`);
                     const data = await res.json();
-                    if (statusEl) statusEl.textContent = 'Enviado';
+                    if (statusEl) statusEl.textContent = 'Sent';
                     const parts = [];
-                    if (data.comment_url) parts.push(`Comentario: ${data.comment_url}`);
+                    if (data.comment_url) parts.push(`Comment: ${data.comment_url}`);
                     if (data.hash) parts.push(`Hash: ${data.hash}`);
                     if (data.karma !== undefined) parts.push(`Karma: ${data.karma}`);
                     if (data.user_token && !token) parts.push(`Token: ${data.user_token}`);
                     if (resultEl) resultEl.textContent = parts.join(' · ');
                 } catch (e) {
                     if (statusEl) statusEl.textContent = 'Error';
-                    if (resultEl) resultEl.textContent = 'No se pudo enviar. Verifica el número de PR y que el repositorio exista.';
+                    if (resultEl) resultEl.textContent = 'Could not send it. Check the PR number and that the repository exists.';
                 } finally {
                     if (btn) btn.disabled = false;
                 }
@@ -5139,7 +5215,7 @@
                     }
                 } catch {}
             } else {
-                // Sin token: mostrar el límite no autenticado sin llamar a la API (evita el 403 de GitHub).
+                // No token: show the unauthenticated limit without calling the API (avoids GitHub 403s).
                 document.getElementById('rl-remaining').textContent = '60 / hour';
                 document.getElementById('rl-limit').textContent = '';
                 updateRateLimitRing('rl-bar', 100, 'var(--accent)');
@@ -5370,7 +5446,7 @@
                     const max = Math.max(...values, 1);
                     chart.replaceChildren();
                     if (!values.length) {
-                        chart.innerHTML = '<span style="width:100%;text-align:center;color:var(--fg-muted);font-size:0.62rem;padding-bottom:0.35rem;">Sin visitas todavía</span>';
+                        chart.innerHTML = '<span style="width:100%;text-align:center;color:var(--fg-muted);font-size:0.62rem;padding-bottom:0.35rem;">No visits yet</span>';
                         return;
                     }
                     values.forEach((value, index) => {
@@ -5380,7 +5456,7 @@
                         chart.appendChild(bar);
                     });
                 } catch (_) {
-                    chart.innerHTML = '<span style="width:100%;text-align:center;color:var(--fg-muted);font-size:0.62rem;padding-bottom:0.35rem;">Métricas no disponibles</span>';
+                    chart.innerHTML = '<span style="width:100%;text-align:center;color:var(--fg-muted);font-size:0.62rem;padding-bottom:0.35rem;">Metrics unavailable</span>';
                 }
             })();
         </script>


### PR DESCRIPTION
Add support for passing an optional GitHub service token per request (via push-option / API payload). ReceivePack now extracts a github-token push-option (and redacts it from logs) and threads it through to PushToGitHub and GitHub API calls. New token-aware wrappers added in internal/github; HTTP handlers and anonymous endpoints accept github_token; web UI adds a settings panel to save/send a token from the browser. README updated with usage and security guidance. This enables callers to use their own service account/rate-limit without exposing shared credentials.