### PR TITLE
Add clean URLs and client-side routing

### DIFF
--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -322,11 +322,33 @@ func SetupRouter(cfg *config.Config) *gin.Engine {
 	r.GET("/api/status", ServiceStatusHandler)
 
 	r.NoRoute(func(c *gin.Context) {
-		// Rutas limpias de perfil de usuario/organización: /gh/:username, /gl/:username, /cb/:username
 		if c.Request.Method == http.MethodGet {
 			parts := strings.Split(strings.Trim(c.Request.URL.Path, "/"), "/")
-			if len(parts) == 2 && (parts[0] == "gh" || parts[0] == "gl" || parts[0] == "cb") {
-				c.File("./web/profile.html")
+			isProvider := len(parts) > 0 && (parts[0] == "gh" || parts[0] == "gl" || parts[0] == "cb")
+			if isProvider && len(parts) >= 2 {
+				if len(parts) == 2 {
+					c.File("./web/profile.html")
+					return
+				}
+				profileViews := map[string]bool{
+					"stars": true, "followers": true, "following": true,
+					"members": true, "projects": true, "packages": true,
+				}
+				if len(parts) == 3 && profileViews[parts[2]] {
+					c.File("./web/profile.html")
+					return
+				}
+				c.File("./web/repo.html")
+				return
+			}
+			knownPages := map[string]bool{
+				"explore": true, "cli": true, "git-extension": true,
+				"settings": true, "issue": true, "comment": true,
+				"pr-comment": true, "legal": true, "about": true,
+				"stats": true,
+			}
+			if len(parts) == 1 && knownPages[parts[0]] {
+				c.File("./web/index.html")
 				return
 			}
 		}

--- a/web/index.html
+++ b/web/index.html
@@ -3393,7 +3393,7 @@
                         const owner = parts[0] || repo.owner || '';
                         const name  = parts[1] || repo.name  || '';
                         if (owner && name) {
-                            window.location.href = `/repo.html?owner=${encodeURIComponent(owner)}&repo=${encodeURIComponent(name)}&provider=${provider}`;
+                            window.location.href = `/${provider}/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`;
                         } else { window.location.href = repo.url; }
                     };
 
@@ -3653,7 +3653,7 @@
                     else if (repo.provider === 'codeberg' || repo.provider === 'cb') provider = 'cb';
                     else provider = 'gh';
                     item.onclick = () => {
-                        window.location.href = `/repo.html?owner=${encodeURIComponent(repo.owner)}&repo=${encodeURIComponent(repo.repo)}&provider=${provider}`;
+                        window.location.href = `/${provider}/${encodeURIComponent(repo.owner)}/${encodeURIComponent(repo.repo)}`;
                     };
                     const ago = timeAgo(repo.starred_at);
                     const forgeIcon = forgeIconHtml(repo.provider);
@@ -3932,7 +3932,8 @@
             function updateStatusbar(section, value = "") {
                 const statusbarPath = document.getElementById("statusbar-path");
                 if (!statusbarPath) return;
-                statusbarPath.textContent = `home > ${section}${value ? " > " + value : ""}`;
+                const homePath = PAGE_TO_PATH['home'] || '/explore';
+                statusbarPath.innerHTML = `<a href="${homePath}" onclick="showPage('home');return false;" style="color:var(--fg-secondary);text-decoration:none;">home</a> &gt; ${section}${value ? " &gt; " + value : ""}`;
             }
 
             const PAGES = {
@@ -4669,13 +4670,27 @@
                 }
             };
 
-            function showPage(name) {
+            const PAGE_TO_PATH = { home: '/explore', cli: '/cli', 'git-extension': '/git-extension', settings: '/settings', issue: '/issue', comment: '/comment', 'pr-comment': '/pr-comment', legal: '/legal', about: '/about', stats: '/stats' };
+            const PATH_TO_PAGE = {};
+            for (const [k, v] of Object.entries(PAGE_TO_PATH)) PATH_TO_PAGE[v] = k;
+            function pageFromPath() {
+                const pp = window.location.pathname.split('/').filter(Boolean);
+                return (pp.length === 1 && PATH_TO_PAGE['/' + pp[0]]) ? PATH_TO_PAGE['/' + pp[0]] : 'home';
+            }
+
+            function showPage(name, push) {
+                if (push === undefined) push = true;
                 document.querySelectorAll('.nav-link').forEach(l => l.classList.remove('active'));
                 document.querySelectorAll('.nav-link').forEach(l => {
                     if (l.getAttribute('onclick') && l.getAttribute('onclick').includes(`'${name}'`)) {
                         l.classList.add('active');
                     }
                 });
+
+                if (push) {
+                    const path = PAGE_TO_PATH[name] || PAGE_TO_PATH['home'];
+                    history.pushState({ page: name }, '', path);
+                }
 
                 const repoList = document.getElementById('repo-list');
                 const contentTabs = document.querySelector('.content-tabs');
@@ -5064,7 +5079,7 @@
                     else if (repo.provider === 'codeberg') provider = 'cb';
                     else provider = 'gh';
                     item.onclick = () => {
-                        if (owner && name) window.location.href = `/repo.html?owner=${encodeURIComponent(owner)}&repo=${encodeURIComponent(name)}&provider=${provider}`;
+                        if (owner && name) window.location.href = `/${provider}/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`;
                     };
                     const desc = repo.description ? escapeHtml(repo.description.slice(0, 120)) : '';
                     const stars = repo.stars > 0 ? `(${STAR_ICON_HTML}${formatNumber(repo.stars)})` : '';
@@ -5101,6 +5116,7 @@
             const _initQ   = _initParams.get('q');
             (function init() {
                 const colorsLoaded = loadLanguageColors();
+                const initPage = pageFromPath();
                 if (_initTag) {
                     showTagPage(_initTag);
                 } else if (_initQ && searchInput) {
@@ -5108,11 +5124,23 @@
                     removeSentinel();
                     scrollState.exhausted = true;
                     performSearch(_initQ);
+                } else if (initPage !== 'home') {
+                    showPage(initPage, false);
                 } else {
                     loadTrending();
                 }
                 colorsLoaded.then(loaded => {
                     if (loaded) refreshLanguageBadges();
+                });
+
+                window.addEventListener('popstate', function() {
+                    const p = pageFromPath();
+                    showPage(p, false);
+                });
+
+                document.querySelectorAll('.nav-link[onclick]').forEach(a => {
+                    const m = a.getAttribute('onclick').match(/showPage\('([^']+)'\)/);
+                    if (m) a.href = PAGE_TO_PATH[m[1]] || '/explore';
                 });
             })();
 

--- a/web/profile.html
+++ b/web/profile.html
@@ -726,6 +726,16 @@
         if (_qpProvider) PROVIDER = (_qpProvider === 'gl' || _qpProvider === 'cb') ? _qpProvider : 'gh';
         if (_qpUser) USERNAME = _qpUser;
 
+        const PROFILE_VIEWS = { stars: 'stars', followers: 'followers', following: 'following', members: 'members', projects: 'projects', packages: 'packages' };
+        const _viewPart = (_pathParts.length >= 3) ? _pathParts[2] : '';
+        const _initialView = PROFILE_VIEWS[_viewPart] || 'overview';
+
+        function profileViewUrl(view) {
+            const base = `/${encodeURIComponent(PROVIDER)}/${encodeURIComponent(USERNAME)}`;
+            const suffix = PROFILE_VIEWS[view] || '';
+            return suffix ? `${base}/${suffix}` : base;
+        }
+
         const STAR_ICON_HTML = `<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" style="vertical-align:-0.125em;"><path d="M0 0h24v24H0z" fill="none"/><path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M10.704 4.325a1.5 1.5 0 0 1 2.592 0l1.818 3.12a1.5 1.5 0 0 0 .978.712l3.53.764a1.5 1.5 0 0 1 .8 2.465l-2.405 2.693a1.5 1.5 0 0 0-.374 1.15l.363 3.593a1.5 1.5 0 0 1-2.097 1.524l-3.304-1.456a1.5 1.5 0 0 0-1.21 0l-3.304 1.456a1.5 1.5 0 0 1-2.097-1.524l.363-3.593a1.5 1.5 0 0 0-.373-1.15l-2.406-2.693a1.5 1.5 0 0 1 .8-2.465l3.53-.764a1.5 1.5 0 0 0 .979-.711z"/></svg>`;
         const X_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="1em" height="1em" role="img" style="vertical-align:-0.125em;"><path fill="currentColor" d="M9.332 6.925 14.544 1h-1.235L8.783 6.145 5.17 1H1l5.466 7.78L1 14.993h1.235l4.78-5.433 3.816 5.433H15L9.332 6.925ZM7.64 8.848l-.554-.775L2.68 1.91h1.897l3.556 4.975.554.775 4.622 6.466h-1.897L7.64 8.848Z"></path></svg>`;
         const MAIL_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="1em" height="1em" role="img" style="vertical-align:-0.125em;"><path fill="currentColor" d="M1.75 2h12.5c.966 0 1.75.784 1.75 1.75v8.5A1.75 1.75 0 0 1 14.25 14H1.75A1.75 1.75 0 0 1 0 12.25v-8.5C0 2.784.784 2 1.75 2ZM1.5 12.251c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25V5.809L8.38 9.397a.75.75 0 0 1-.76 0L1.5 5.809v6.442Zm13-8.181v-.32a.25.25 0 0 0-.25-.25H1.75a.25.25 0 0 0-.25.25v.32L8 7.88Z"></path></svg>`;
@@ -957,7 +967,7 @@
             return `
                 <div class="repo-card">
                     <div class="repo-card-head">
-                        <a class="repo-name" href="/repo.html?owner=${encodeURIComponent(owner)}&repo=${encodeURIComponent(name)}&provider=${encodeURIComponent(PROVIDER)}">${safeOwner} / ${safeName}</a>
+                        <a class="repo-name" href="/${encodeURIComponent(PROVIDER)}/${encodeURIComponent(owner)}/${encodeURIComponent(name)}">${safeOwner} / ${safeName}</a>
                         <span class="repo-visibility">${visibility}</span>
                     </div>
                     ${desc ? `<p class="repo-desc">${desc}</p>` : ''}
@@ -1052,7 +1062,8 @@
             switchView('packages');
         }
 
-        function switchView(view) {
+        function switchView(view, push) {
+            if (push === undefined) push = true;
             if (_currentView === view) return;
             const prev = _currentView;
             const isOverview = view === 'overview';
@@ -1061,6 +1072,10 @@
             const isProjects = view === 'projects';
             const isPackages = view === 'packages';
             _currentView = view;
+
+            if (push) {
+                history.pushState({ view: view }, '', profileViewUrl(view));
+            }
 
             if (!isOverview && prev === 'overview') _prevTitle = document.title;
             if (isOverview) {
@@ -1101,7 +1116,7 @@
             const starredTitle = document.getElementById('starred-section-title');
             const starredSec = document.getElementById('starred-section');
             if (!starredTitle || !starredSec) return;
-            starredTitle.innerHTML = '<a class="stars-back" href="#" onclick="switchView(\'overview\'); return false;">‹ back to profile</a>';
+            starredTitle.innerHTML = '<a class="stars-back" href="' + profileViewUrl('overview') + '" onclick="switchView(\'overview\'); return false;">&#x2039; back to profile</a>';
             const starred = _starredCache || (_starredCache = await fetchStarred());
             const navStars = document.getElementById('nav-star-count');
             if (navStars && starred.length > 0) navStars.textContent = formatNumber(starred.length);
@@ -1153,7 +1168,7 @@
             const titleEl = document.getElementById('projects-section-title');
             const listEl = document.getElementById('projects-section');
             if (!titleEl || !listEl) return;
-            titleEl.innerHTML = '<a class="stars-back" href="#" onclick="switchView(\'overview\'); return false;">‹ back to profile</a>';
+            titleEl.innerHTML = '<a class="stars-back" href="' + profileViewUrl('overview') + '" onclick="switchView(\'overview\'); return false;">&#x2039; back to profile</a>';
             const projects = _projectsCache || (_projectsCache = await fetchProjects());
             const navCount = document.getElementById('nav-projects-count');
             if (navCount && projects.length > 0) navCount.textContent = formatNumber(projects.length);
@@ -1213,7 +1228,7 @@
             const titleEl = document.getElementById('packages-section-title');
             const listEl = document.getElementById('packages-section');
             if (!titleEl || !listEl) return;
-            titleEl.innerHTML = '<a class="stars-back" href="#" onclick="switchView(\'overview\'); return false;">‹ back to profile</a>';
+            titleEl.innerHTML = '<a class="stars-back" href="' + profileViewUrl('overview') + '" onclick="switchView(\'overview\'); return false;">&#x2039; back to profile</a>';
             const packages = _packagesCache || (_packagesCache = await fetchPackages());
             const navCount = document.getElementById('nav-packages-count');
             if (navCount && packages.length > 0) navCount.textContent = formatNumber(packages.length);
@@ -1306,7 +1321,7 @@
             const listEl = document.getElementById('people-section');
             if (!titleEl || !listEl) return;
             const label = kind === 'followers' ? 'followers' : kind === 'following' ? 'following' : 'members';
-            titleEl.innerHTML = `<a class="stars-back" href="#" onclick="switchView('overview'); return false;">‹ back to profile</a> <span class="stars-count">${label}</span>`;
+            titleEl.innerHTML = '<a class="stars-back" href="' + profileViewUrl('overview') + '" onclick="switchView(\'overview\'); return false;">&#x2039; back to profile</a> <span class="stars-count">' + label + '</span>';
             // Los miembros de una organización de Codeberg ya vienen en el perfil (public_members).
             let people;
             if (kind === 'members') {
@@ -1661,6 +1676,29 @@
             if (readme.text) renderReadme(readme.text, readme.baseUrl);
 
             checkServiceStatus();
+
+            if (_initialView !== 'overview') {
+                switchView(_initialView, false);
+            }
+
+            window.addEventListener('popstate', function() {
+                const vp = window.location.pathname.split('/').filter(Boolean);
+                const sv = (vp.length >= 3) ? PROFILE_VIEWS[vp[2]] || 'overview' : 'overview';
+                if (sv !== _currentView) switchView(sv, false);
+            });
+
+            document.querySelectorAll('.left-nav a[onclick]').forEach(a => {
+                const onclick = a.getAttribute('onclick');
+                const m = onclick.match(/navOverview|navRepos|openStars|openProjects|openPackages|openPeople/);
+                if (m) {
+                    const map = { navOverview: 'overview', navRepos: 'overview', openStars: 'stars', openProjects: 'projects', openPackages: 'packages' };
+                    if (map[m[0]]) a.href = profileViewUrl(map[m[0]]);
+                    else if (m[0] === 'openPeople') {
+                        const km = onclick.match(/openPeople\('(\w+)'\)/);
+                        if (km) a.href = profileViewUrl(km[1]);
+                    }
+                }
+            });
         }
 
         // ---- Markdown (simplificado de repo.html) ----

--- a/web/repo.html
+++ b/web/repo.html
@@ -2793,18 +2793,45 @@
                 .replace(/\u2028/g, '\\u2028')
                 .replace(/\u2029/g, '\\u2029');
         }
+
+        const _pathParts = window.location.pathname.split('/').filter(Boolean);
+        const _isCleanPath = _pathParts.length >= 3 && (_pathParts[0] === 'gh' || _pathParts[0] === 'gl' || _pathParts[0] === 'cb');
         const rv = {
-            owner:    params.get('owner') || '',
-            repo:     params.get('repo')  || '',
-            provider: params.get('provider') || 'gh',
+            owner:    _isCleanPath ? decodeURIComponent(_pathParts[1] || '') : (params.get('owner') || ''),
+            repo:     _isCleanPath ? decodeURIComponent(_pathParts[2] || '') : (params.get('repo')  || ''),
+            provider: _isCleanPath ? _pathParts[0] : (params.get('provider') || 'gh'),
             branch:   params.get('branch') || '',
             path:     [],
         };
+        if (!_isCleanPath) {
+            if (rv.provider === 'github') rv.provider = 'gh';
+            else if (rv.provider === 'gitlab') rv.provider = 'gl';
+            else if (rv.provider === 'codeberg') rv.provider = 'cb';
+        }
 
-        // Normalize provider to match index page format (github->gh, gitlab->gl, codeberg->cb)
-        if (rv.provider === 'github') rv.provider = 'gh';
-        else if (rv.provider === 'gitlab') rv.provider = 'gl';
-        else if (rv.provider === 'codeberg') rv.provider = 'cb';
+        const VIEW_TO_PATH = {
+            home: '', files: 'tree', commits: 'commits', branches: 'branches',
+            packages: 'packages', bugs: 'issues', reviews: 'pulls',
+            discussions: 'discussions', wiki: 'wiki', releases: 'releases',
+            tags: 'tags', deployments: 'deployments', contributors: 'contributors',
+        };
+        const PATH_TO_VIEW = {};
+        for (const [k, v] of Object.entries(VIEW_TO_PATH)) {
+            if (v) PATH_TO_VIEW[v] = k;
+        }
+        function repoBasePath() {
+            return `/${rv.provider}/${encodeURIComponent(rv.owner)}/${encodeURIComponent(rv.repo)}`;
+        }
+        function buildViewUrl(view) {
+            const suffix = VIEW_TO_PATH[view] || '';
+            return suffix ? `${repoBasePath()}/${suffix}` : repoBasePath();
+        }
+        function viewFromPath() {
+            if (_isCleanPath && _pathParts.length >= 4) {
+                return PATH_TO_VIEW[_pathParts[3]] || 'home';
+            }
+            return 'home';
+        }
 
         function profileLink(username, label, className = '') {
             const name = String(username || '').trim();
@@ -2824,7 +2851,7 @@
             el.innerHTML =
                 `<a href="/${encodeURIComponent(rv.provider)}/${encodeURIComponent(rv.owner)}" style="color:var(--fg-muted);text-decoration:none;" onmouseover="this.style.color='var(--accent)'" onmouseout="this.style.color='var(--fg-muted)'">${escHtml(rv.owner)}</a>`+
                 `<span style="color:var(--fg-muted);">/</span>`+
-                `<a href="#" onclick="showView('home');return false;" style="color:var(--fg-muted);text-decoration:none;" onmouseover="this.style.color='var(--accent)'" onmouseout="this.style.color='var(--fg-muted)'">${escHtml(rv.repo)}</a>`+
+                `<a href="${repoBasePath()}" onclick="showView('home');return false;" style="color:var(--fg-muted);text-decoration:none;" onmouseover="this.style.color='var(--accent)'" onmouseout="this.style.color='var(--fg-muted)'">${escHtml(rv.repo)}</a>`+
                 (branchName ? `<span style="color:var(--fg-muted);">/</span><span style="color:var(--fg-muted);display:inline-flex;align-items:center;gap:0.25rem;">${BRANCH_SVG}${branchName}</span>` : '');
         }
 
@@ -2858,15 +2885,32 @@
             checkPackages();
             const codePanel = document.getElementById('code-panel');
             if (codePanel) codePanel.addEventListener('click', handlePanelLinkClick);
-            showView('home');
+            showView(viewFromPath(), false);
+
+            window.addEventListener('popstate', function() {
+                const v = viewFromPath();
+                if (v) showView(v, false);
+            });
+
+            document.querySelectorAll('a[onclick]').forEach(a => {
+                const m = a.getAttribute('onclick').match(/showView\('([^']+)'\)/);
+                if (m) {
+                    a.href = buildViewUrl(m[1]);
+                }
+            });
         }
 
-        function showView(view) {
+        function showView(view, push) {
+            if (push === undefined) push = true;
             _disposePierreDiffs();
             const navLinks = document.querySelectorAll('.left-nav a');
             navLinks.forEach(a => a.classList.remove('active'));
             const idx = ['home','files','commits','branches','packages','bugs','reviews','discussions','wiki'].indexOf(view);
             if (idx >= 0 && navLinks[idx]) navLinks[idx].classList.add('active');
+
+            if (push) {
+                history.pushState({ view: view }, '', buildViewUrl(view));
+            }
 
             const fileTree = document.getElementById('file-tree');
             const codePanel = document.getElementById('code-panel');
@@ -5977,7 +6021,7 @@
                 const img = `<img src="${escAttr(avatar)}" alt="${escAttr(username)}" loading="lazy">`;
                 const title = `${escAttr(username)} · ${commits} commits${top ? ' · top contributor' : ''}`;
                 if (!login) return `<span class="sb-contributor${top ? ' top' : ''}" title="${title}">${img}</span>`;
-                return `<a class="sb-contributor${top ? ' top' : ''}" href="/profile.html?provider=${encodeURIComponent(rv.provider)}&user=${encodeURIComponent(login)}" title="${title}">${img}</a>`;
+                return `<a class="sb-contributor${top ? ' top' : ''}" href="/${encodeURIComponent(rv.provider)}/${encodeURIComponent(login)}" title="${title}">${img}</a>`;
             }).join('');
             if (!html) return;
             box.innerHTML = html;
@@ -6080,10 +6124,10 @@
                     ? `<img src="${escAttr(avatar)}" alt="${escAttr(username)}" loading="lazy" style="width:2rem;height:2rem;border-radius:50%;object-fit:cover;background:var(--accent);flex:none;">`
                     : `<span style="width:2rem;height:2rem;border-radius:50%;background:var(--accent);display:inline-flex;align-items:center;justify-content:center;font-size:0.7rem;color:#fff;flex:none;">${escHtml((username || '?')[0].toUpperCase())}</span>`;
                 const avatarHtml = login
-                    ? `<a href="/profile.html?provider=${encodeURIComponent(rv.provider)}&user=${encodeURIComponent(login)}" aria-label="${escAttr(username)} profile">${img}</a>`
+                    ? `<a href="/${encodeURIComponent(rv.provider)}/${encodeURIComponent(login)}" aria-label="${escAttr(username)} profile">${img}</a>`
                     : img;
                 const nameHtml = login
-                    ? `<a href="/profile.html?provider=${encodeURIComponent(rv.provider)}&user=${encodeURIComponent(login)}" style="color:var(--fg);text-decoration:none;font-weight:500;">${escHtml(username)}</a>`
+                    ? `<a href="/${encodeURIComponent(rv.provider)}/${encodeURIComponent(login)}" style="color:var(--fg);text-decoration:none;font-weight:500;">${escHtml(username)}</a>`
                     : `<span style="color:var(--fg);font-weight:500;">${escHtml(username)}</span>`;
                 const meta = `${escHtml(commits)} commit${commits !== 1 ? 's' : ''}`;
                 const metaHtml = top


### PR DESCRIPTION
Serve profile/repo pages with clean paths and enable client-side history navigation. Router: handle no-route GETs for /{provider}/{user}[/{view}] and /{provider}/{owner}/{repo}[/{view}], serving profile.html, repo.html or index.html as appropriate. Web UI (index.html, profile.html, repo.html): switch links from query params to /{provider}/{owner}/{repo} and /{provider}/{user} form, add PAGE/VIEW <-> path maps, pushState/popstate handling, and functions to build/parse clean URLs while keeping query-param fallbacks and provider-name normalization.