### PR TITLE
Add GitHub API proxy and use in UI

### DIFF
--- a/internal/http/github_proxy_test.go
+++ b/internal/http/github_proxy_test.go
@@ -1,0 +1,52 @@
+package http
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestGitHubAPIProxyHandler(t *testing.T) {
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Host != "api.github.com" {
+			t.Fatalf("proxy target host = %q, want api.github.com", req.URL.Host)
+		}
+		if req.URL.Path != "/repos/owner/repo/issues/1/comments" || req.URL.RawQuery != "per_page=100" {
+			t.Fatalf("proxy target = %s?%s", req.URL.Path, req.URL.RawQuery)
+		}
+		if req.Header.Get("Authorization") != "token client-token" {
+			t.Fatalf("authorization = %q", req.Header.Get("Authorization"))
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(`[{"id":1}]`)),
+			Request: req,
+		}, nil
+	})
+	defer func() { http.DefaultTransport = oldTransport }()
+	t.Setenv("GITHUB_TOKEN", "")
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/api/gh-proxy/*path", GitHubAPIProxyHandler)
+	req := httptest.NewRequest(http.MethodGet, "/api/gh-proxy/repos/owner/repo/issues/1/comments?per_page=100", nil)
+	req.Header.Set("Authorization", "token client-token")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK || w.Body.String() != `[{"id":1}]` {
+		t.Fatalf("response = %d %q", w.Code, w.Body.String())
+	}
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}

--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -3186,6 +3186,53 @@ func CodebergProxyHandler(c *gin.Context) {
 	}
 }
 
+// GitHubAPIProxyHandler keeps browser requests to api.github.com on the server.
+func GitHubAPIProxyHandler(c *gin.Context) {
+	path := strings.TrimPrefix(c.Request.URL.Path, "/api/gh-proxy/")
+	if path == "" || strings.Contains(path, "..") {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid GitHub API path"})
+		return
+	}
+
+	target := "https://api.github.com/" + path
+	if c.Request.URL.RawQuery != "" {
+		target += "?" + c.Request.URL.RawQuery
+	}
+	req, err := http.NewRequestWithContext(c.Request.Context(), c.Request.Method, target, nil)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to build request"})
+		return
+	}
+
+	token := tokenpool.NextGitHubToken()
+	if token == "" {
+		token = strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(c.GetHeader("Authorization"), "token "), "Bearer "))
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "token "+token)
+	}
+	req.Header.Set("Accept", c.GetHeader("Accept"))
+	req.Header.Set("User-Agent", "gitGost")
+
+	resp, err := (&http.Client{Timeout: 15 * time.Second}).Do(req)
+	if err != nil {
+		utils.Log("GitHub API proxy error: %v", err)
+		c.AbortWithStatusJSON(http.StatusBadGateway, gin.H{"error": "failed to reach GitHub"})
+		return
+	}
+	defer resp.Body.Close()
+
+	for _, header := range []string{"Content-Type", "Cache-Control", "ETag", "Link", "X-RateLimit-Limit", "X-RateLimit-Remaining", "X-RateLimit-Reset"} {
+		if value := resp.Header.Get(header); value != "" {
+			c.Writer.Header().Set(header, value)
+		}
+	}
+	c.Writer.WriteHeader(resp.StatusCode)
+	if _, err := io.Copy(c.Writer, resp.Body); err != nil {
+		utils.Log("GitHub API proxy copy error: %v", err)
+	}
+}
+
 func SearchHandler(c *gin.Context) {
 	query := c.Query("q")
 	provider := c.Query("provider")

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -310,6 +310,7 @@ func SetupRouter(cfg *config.Config) *gin.Engine {
 		api.GET("/users/orgs", prCheckLimiter(), UserOrgsHandler)
 		api.GET("/users/events", prCheckLimiter(), UserEventsHandler)
 		api.GET("/users/contributions", prCheckLimiter(), UserContributionsHandler)
+		api.GET("/gh-proxy/*path", prCheckLimiter(), GitHubAPIProxyHandler)
 		api.GET("/trending/:provider", TrendingHandler)
 		api.GET("/cb-proxy/*path", prCheckLimiter(), CodebergProxyHandler)
 		api.GET("/gl-notes/:owner/:repo/:number", GitLabIssueNotesProxyHandler)

--- a/web/index.html
+++ b/web/index.html
@@ -5,85 +5,85 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <link
             rel="shortcut icon"
-            href="assets/logos/gitgost-logo.svg"
+            href="/assets/logos/gitgost-logo.svg"
             type="image/svg+xml"
         />
-        <link rel="icon" href="assets/logos/gitgost-logo.svg" type="image/svg+xml" />
+        <link rel="icon" href="/assets/logos/gitgost-logo.svg" type="image/svg+xml" />
         <title>gitGost — Anonymous Git Contributions</title>
         <link
             rel="apple-touch-icon"
             sizes="57x57"
-            href="assets/logos/apple-icon-57x57.png"
+            href="/assets/logos/apple-icon-57x57.png"
         />
         <link
             rel="apple-touch-icon"
             sizes="60x60"
-            href="assets/logos/apple-icon-60x60.png"
+            href="/assets/logos/apple-icon-60x60.png"
         />
         <link
             rel="apple-touch-icon"
             sizes="72x72"
-            href="assets/logos/apple-icon-72x72.png"
+            href="/assets/logos/apple-icon-72x72.png"
         />
         <link
             rel="apple-touch-icon"
             sizes="76x76"
-            href="assets/logos/apple-icon-76x76.png"
+            href="/assets/logos/apple-icon-76x76.png"
         />
         <link
             rel="apple-touch-icon"
             sizes="114x114"
-            href="assets/logos/apple-icon-114x114.png"
+            href="/assets/logos/apple-icon-114x114.png"
         />
         <link
             rel="apple-touch-icon"
             sizes="120x120"
-            href="assets/logos/apple-icon-120x120.png"
+            href="/assets/logos/apple-icon-120x120.png"
         />
         <link
             rel="apple-touch-icon"
             sizes="144x144"
-            href="assets/logos/apple-icon-144x144.png"
+            href="/assets/logos/apple-icon-144x144.png"
         />
         <link
             rel="apple-touch-icon"
             sizes="152x152"
-            href="assets/logos/apple-icon-152x152.png"
+            href="/assets/logos/apple-icon-152x152.png"
         />
         <link
             rel="apple-touch-icon"
             sizes="180x180"
-            href="assets/logos/apple-icon-180x180.png"
+            href="/assets/logos/apple-icon-180x180.png"
         />
         <link
             rel="icon"
             type="image/png"
             sizes="192x192"
-            href="assets/logos/android-icon-192x192.png"
+            href="/assets/logos/android-icon-192x192.png"
         />
         <link
             rel="icon"
             type="image/png"
             sizes="32x32"
-            href="assets/logos/favicon-32x32.png"
+            href="/assets/logos/favicon-32x32.png"
         />
         <link
             rel="icon"
             type="image/png"
             sizes="96x96"
-            href="assets/logos/favicon-96x96.png"
+            href="/assets/logos/favicon-96x96.png"
         />
         <link
             rel="icon"
             type="image/png"
             sizes="16x16"
-            href="assets/logos/favicon-16x16.png"
+            href="/assets/logos/favicon-16x16.png"
         />
-        <link rel="manifest" href="assets/logos/manifest.json" />
+        <link rel="manifest" href="/assets/logos/manifest.json" />
         <meta name="msapplication-TileColor" content="#d16014" />
         <meta
             name="msapplication-TileImage"
-            content="assets/logos/ms-icon-144x144.png"
+            content="/assets/logos/ms-icon-144x144.png"
         />
         <meta name="theme-color" content="#d16014" />
         <script>
@@ -4510,7 +4510,7 @@
                             </div>
 
                             <div style="display:flex;flex-direction:column;align-items:center;text-align:center;padding:1.5rem 0 2rem;border-bottom:1px solid var(--border);">
-                                <img src="assets/logos/gitgost-logo.svg" width="72" height="72" style="margin-bottom:1rem;" alt="gitGost logo" />
+                                <img src="/assets/logos/gitgost-logo.svg" width="72" height="72" style="margin-bottom:1rem;" alt="gitGost logo" />
                                 <h2 style="font-size:1.75rem;font-weight:700;margin:0 0 0.5rem;color:var(--fg);font-family:'IBM Plex Mono',monospace;">gitGost</h2>
                                 <p style="font-size:1rem;color:var(--fg-muted);margin:0 0 1.5rem;max-width:520px;">Contribute to any Git repository without exposing your identity.</p>
                                 <a href="#" onclick="showPage('cli'); return false;" class="btn primary" style="text-decoration:none;display:inline-block;">Start Contributing Anonymously</a>
@@ -5298,7 +5298,8 @@
             const token = localStorage.getItem('gh_token');
             if (token) {
                 try {
-                    const res = await fetch('https://api.github.com/rate_limit', { headers: { 'Authorization': `token ${token}` } });
+                    const proxyURL = `${API_BASE}/api/gh-proxy/rate_limit`;
+                    const res = await fetch(proxyURL, { headers: { 'Authorization': `token ${token}` } });
                     if (res.ok) {
                         const core = (await res.json()).rate;
                         const pct  = core.limit > 0 ? Math.round((core.remaining / core.limit) * 100) : 0;

--- a/web/profile.html
+++ b/web/profile.html
@@ -845,6 +845,15 @@
             return token ? { 'Authorization': 'token ' + token } : {};
         }
 
+        function ghFetch(url, opts = {}) {
+            const target = new URL(url, window.location.href);
+            if (target.hostname === 'api.github.com') {
+                const proxyBase = new URL(`${API_BASE}/api/gh-proxy`);
+                return fetch(new URL(`${proxyBase.pathname}${target.pathname}${target.search}`, proxyBase.origin), opts);
+            }
+            return fetch(target.toString(), opts);
+        }
+
         async function apiGet(path) {
             try {
                 const res = await fetch(`${API_BASE}${path}`, { headers: authHeaders() });
@@ -1145,10 +1154,10 @@
             const headers = authHeaders();
             headers['Accept'] = 'application/vnd.github+json';
             try {
-                let res = await fetch(`https://api.github.com/users/${encodeURIComponent(USERNAME)}/projects?per_page=100`, { headers });
+                let res = await ghFetch(`https://api.github.com/users/${encodeURIComponent(USERNAME)}/projects?per_page=100`, { headers });
                 // Los projects de una organización usan la ruta /orgs/...
                 if (res.status === 404) {
-                    res = await fetch(`https://api.github.com/orgs/${encodeURIComponent(USERNAME)}/projects?per_page=100`, { headers });
+                    res = await ghFetch(`https://api.github.com/orgs/${encodeURIComponent(USERNAME)}/projects?per_page=100`, { headers });
                 }
                 if (!res.ok) return [];
                 const data = await res.json();
@@ -1277,7 +1286,7 @@
                 if (PROVIDER === 'gh') {
                     const headers = authHeaders();
                     for (let page = 1; page <= 10; page++) {
-                        const res = await fetch(`https://api.github.com/users/${encodeURIComponent(USERNAME)}/${path}?per_page=100&page=${page}`, { headers });
+                        const res = await ghFetch(`https://api.github.com/users/${encodeURIComponent(USERNAME)}/${path}?per_page=100&page=${page}`, { headers });
                         if (!res.ok) break;
                         const items = await res.json();
                         if (!Array.isArray(items) || items.length === 0) break;
@@ -1363,7 +1372,7 @@
                     }));
                 }
                 if (PROVIDER === 'gh') {
-                    const res = await fetch(`https://api.github.com/users/${encodeURIComponent(USERNAME)}/orgs?per_page=100`, { headers: authHeaders() });
+                    const res = await ghFetch(`https://api.github.com/users/${encodeURIComponent(USERNAME)}/orgs?per_page=100`, { headers: authHeaders() });
                     if (!res.ok) return [];
                     const items = await res.json();
                     if (!Array.isArray(items)) return [];

--- a/web/repo.html
+++ b/web/repo.html
@@ -5,10 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link
             rel="shortcut icon"
-            href="assets/logos/gitgost-logo.svg"
+            href="/assets/logos/gitgost-logo.svg"
             type="image/svg+xml"
         />
-    <link rel="icon" href="assets/logos/gitgost-logo.svg" type="image/svg+xml" />
+    <link rel="icon" href="/assets/logos/gitgost-logo.svg" type="image/svg+xml" />
     <title>gitGost — repo</title>
     <link id="hljs-theme-light" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/styles/github.min.css" />
     <link id="hljs-theme-dark" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.10.0/styles/github-dark.min.css" disabled />
@@ -2764,7 +2764,20 @@
             if (token) {
                 opts.headers = { ...(opts.headers || {}), 'Authorization': `token ${token}` };
             }
-            return fetch(url, opts).then(res => {
+            const target = new URL(url, window.location.href);
+            if (target.hostname === 'api.github.com') {
+                const proxyBase = new URL(`${API_BASE}/api/gh-proxy`);
+                return fetch(new URL(`${proxyBase.pathname}${target.pathname}${target.search}`, proxyBase.origin), opts).then(res => {
+                    if (res.status === 403 || res.status === 429) {
+                        return res.json().catch(() => ({})).then(body => {
+                            const msg = body.message || `rate limit exceeded (${res.status})`;
+                            throw new Error(msg + ' — set a GitHub token in settings to fix this');
+                        });
+                    }
+                    return res;
+                });
+            }
+            return fetch(target.toString(), opts).then(res => {
                 if (res.status === 403 || res.status === 429) {
                     return res.json().catch(() => ({})).then(body => {
                         const msg = body.message || `rate limit exceeded (${res.status})`;
@@ -3187,7 +3200,7 @@
                         <ul class="comment-list" id="${listId}"></ul>
                         <div class="reply-section">
                             <div class="reply-row">
-                                <div class="reply-avatar"><img src="assets/logos/noun-anonymous-6758229.svg" width="16" height="16" style="display:block;" /></div>
+                                <div class="reply-avatar"><img src="/assets/logos/noun-anonymous-6758229.svg" width="16" height="16" style="display:block;" /></div>
                                 <div class="reply-box">
                                     <div class="reply-tabs">
                                         <button type="button" class="reply-tab active" data-mode="write" onclick="setReplyTab('${escJsStr(replyId)}','write')">Write</button>
@@ -3258,7 +3271,7 @@
                     li.innerHTML = `
                         ${cAvatar
                             ? `<img class="comment-avatar" src="${escAttr(cAvatar)}" />`
-                            : `<div class="reply-avatar"><img src="assets/logos/noun-anonymous-6758229.svg" width="16" height="16" style="display:block;" /></div>`}
+                            : `<div class="reply-avatar"><img src="/assets/logos/noun-anonymous-6758229.svg" width="16" height="16" style="display:block;" /></div>`}
                         <div class="comment-bubble">
                             <div class="comment-meta"><strong style="color:var(--fg);">${profileLink(cUser)}</strong> &middot; ${cDate}</div>
                             <div class="readme" style="font-size:0.8rem;">${renderMd(cBody)}</div>
@@ -3920,7 +3933,7 @@
                     const cBody = c.body || '';
                     const answerBadge = c.isAnswer ? '<span class="disc-answer-badge">✓ answer</span>' : '';
                     return `<li class="comment-item">
-                        <div class="reply-avatar"><img src="assets/logos/noun-anonymous-6758229.svg" width="16" height="16" style="display:block;" /></div>
+                        <div class="reply-avatar"><img src="/assets/logos/noun-anonymous-6758229.svg" width="16" height="16" style="display:block;" /></div>
                         <div class="comment-bubble">
                             <div class="comment-meta"><strong style="color:var(--fg);">${profileLink(cUser)}</strong> ${answerBadge} · ${cDate}</div>
                             <div class="readme" style="font-size:0.8rem;">${renderMd(cBody)}</div>
@@ -3949,7 +3962,7 @@
                             <ul class="comment-list">${comments}</ul>
                             <div class="reply-section">
                                 <div class="reply-row">
-                                    <div class="reply-avatar"><img src="assets/logos/noun-anonymous-6758229.svg" width="16" height="16" style="display:block;" /></div>
+                                    <div class="reply-avatar"><img src="/assets/logos/noun-anonymous-6758229.svg" width="16" height="16" style="display:block;" /></div>
                                     <div class="reply-box">
                                         <textarea class="reply-textarea" id="${replyId}" placeholder="Reply..."></textarea>
                                         <menta-widget id="${captchaId}" data-cap-api-endpoint="/api/captcha" data-cap-i18n-initial-state="I'm not a robot"></menta-widget>
@@ -4031,7 +4044,7 @@
                     const li = document.createElement('li');
                     li.className = 'comment-item';
                     li.innerHTML = `
-                        <div class="reply-avatar"><img src="assets/logos/noun-anonymous-6758229.svg" width="16" height="16" style="display:block;" /></div>
+                        <div class="reply-avatar"><img src="/assets/logos/noun-anonymous-6758229.svg" width="16" height="16" style="display:block;" /></div>
                         <div class="comment-bubble">
                             <div class="comment-meta">you · just now${data.hash ? ` · <span style="color:var(--accent)">${escHtml(data.hash)}</span>` : ''}</div>
                             <div>${escHtml(commentBody).replace(/\n/g, '<br>')}</div>
@@ -5332,7 +5345,7 @@
                     const li = document.createElement('li');
                     li.className = 'comment-item';
                     li.innerHTML = `
-                        <div class="reply-avatar"><img src="assets/logos/noun-anonymous-6758229.svg" width="16" height="16" style="display:block;" /></div>
+                        <div class="reply-avatar"><img src="/assets/logos/noun-anonymous-6758229.svg" width="16" height="16" style="display:block;" /></div>
                         <div class="comment-bubble">
                             <div class="comment-meta">you &middot; just now${data.hash ? ` &middot; <span style="color:var(--accent)">${escHtml(data.hash)}</span>` : ''}</div>
                             <div>${escHtml(commentBody).replace(/\n/g, '<br>')}</div>
@@ -5439,7 +5452,7 @@
                         <div class="issue-detail-body readme">${renderedBody}</div>
                         <div class="reply-section">
                             <div class="reply-row">
-                                <div class="reply-avatar"><img src="assets/logos/noun-anonymous-6758229.svg" width="16" height="16" style="display:block;" /></div>
+                                <div class="reply-avatar"><img src="/assets/logos/noun-anonymous-6758229.svg" width="16" height="16" style="display:block;" /></div>
                                 <div class="reply-box">
                                     <div class="reply-tabs">
                                         <button type="button" class="reply-tab active" data-mode="write" onclick="setReplyTab('${escJsStr(replyId)}','write')">Write</button>
@@ -6633,7 +6646,7 @@
             } catch {}
         }
 
-        const ICON_BASE = 'assets/MaterialIconTheme/material-icon-theme--';
+        const ICON_BASE = '/assets/MaterialIconTheme/material-icon-theme--';
 
         // extension -> nombre del svg del tema (fallback: document)
         const _iconExtMap = {


### PR DESCRIPTION
Introduce a server-side GitHub API proxy (GitHubAPIProxyHandler) that forwards browser requests to api.github.com using a token from the pool or the client's Authorization header. Add a unit test for the proxy. Wire the handler into the router at /api/gh-proxy/*path. Update web UI (index, profile, repo) to route GitHub API calls via the proxy (ghFetch) and to use absolute asset paths (/assets/...), including anonymous avatar and icon base updates.