### PR TITLE
Add GitLab proxy and GitHub token rotation

### DIFF
--- a/internal/http/github_proxy_test.go
+++ b/internal/http/github_proxy_test.go
@@ -24,9 +24,9 @@ func TestGitHubAPIProxyHandler(t *testing.T) {
 		}
 		return &http.Response{
 			StatusCode: http.StatusOK,
-			Header: http.Header{"Content-Type": []string{"application/json"}},
-			Body: io.NopCloser(strings.NewReader(`[{"id":1}]`)),
-			Request: req,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`[{"id":1}]`)),
+			Request:    req,
 		}, nil
 	})
 	defer func() { http.DefaultTransport = oldTransport }()
@@ -41,6 +41,72 @@ func TestGitHubAPIProxyHandler(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	if w.Code != http.StatusOK || w.Body.String() != `[{"id":1}]` {
+		t.Fatalf("response = %d %q", w.Code, w.Body.String())
+	}
+}
+
+func TestGitHubAPIProxyHandlerRotatesRateLimitedToken(t *testing.T) {
+	oldTransport := http.DefaultTransport
+	var tokens []string
+	http.DefaultTransport = roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		tokens = append(tokens, req.Header.Get("Authorization"))
+		status := http.StatusTooManyRequests
+		body := `{"message":"rate limit exceeded"}`
+		if len(tokens) == 2 {
+			status = http.StatusOK
+			body = `[{"id":1}]`
+		}
+		return &http.Response{
+			StatusCode: status,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Request:    req,
+		}, nil
+	})
+	defer func() { http.DefaultTransport = oldTransport }()
+	t.Setenv("GITHUB_TOKEN", "first-token")
+	t.Setenv("GITHUB2_TOKEN", "second-token")
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/api/gh-proxy/*path", GitHubAPIProxyHandler)
+	req := httptest.NewRequest(http.MethodGet, "/api/gh-proxy/repos/owner/repo", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK || w.Body.String() != `[{"id":1}]` {
+		t.Fatalf("response = %d %q", w.Code, w.Body.String())
+	}
+	if len(tokens) != 2 || tokens[0] == tokens[1] {
+		t.Fatalf("tokens used = %v", tokens)
+	}
+}
+
+func TestGitLabProxyHandler(t *testing.T) {
+	oldTransport := http.DefaultTransport
+	http.DefaultTransport = roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.Host != "gitlab.com" || req.URL.EscapedPath() != "/api/v4/projects/owner%2Frepo" {
+			t.Fatalf("proxy target = %s%s", req.URL.Host, req.URL.EscapedPath())
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"id":1}`)),
+			Request:    req,
+		}, nil
+	})
+	defer func() { http.DefaultTransport = oldTransport }()
+	t.Setenv("GITLAB_TOKEN", "gl-token")
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/api/gl-proxy/*path", GitLabProxyHandler)
+	req := httptest.NewRequest(http.MethodGet, "/api/gl-proxy/api/v4/projects/owner%2Frepo", nil)
+	req.URL.RawPath = "/api/gl-proxy/api/v4/projects/owner%2Frepo"
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK || w.Body.String() != `{"id":1}` {
 		t.Fatalf("response = %d %q", w.Code, w.Body.String())
 	}
 }

--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -39,6 +39,38 @@ import (
 
 var uploadPackClient = &http.Client{Timeout: 10 * time.Minute}
 
+func doGitHubWithTokenRotation(client *http.Client, buildRequest func(string) (*http.Request, error), fallbackToken string) (*http.Response, error) {
+	tokens := tokenpool.GitHubTokens()
+	if len(tokens) == 0 {
+		req, err := buildRequest(fallbackToken)
+		if err != nil {
+			return nil, err
+		}
+		return client.Do(req)
+	}
+
+	var resp *http.Response
+	for attempt := 0; attempt < len(tokens); attempt++ {
+		token := tokenpool.NextGitHubToken()
+		req, err := buildRequest(token)
+		if err != nil {
+			return nil, err
+		}
+		resp, err = client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode != http.StatusForbidden && resp.StatusCode != http.StatusTooManyRequests {
+			return resp, nil
+		}
+
+		tokenpool.MarkGitHubRateLimited(token, resp.Header.Get("X-RateLimit-Reset"))
+		resp.Body.Close()
+	}
+
+	return resp, nil
+}
+
 const (
 	karmaStoreMax           = 10000
 	reportStoreMax          = 10000
@@ -1736,20 +1768,18 @@ func GitHubDiscussionsProxyHandler(c *gin.Context) {
 		return
 	}
 
-	req, err := http.NewRequest("POST", "https://api.github.com/graphql", bytes.NewBuffer(jsonBody))
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "proxy error"})
-		return
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	ghToken := tokenpool.NextGitHubToken()
-	if ghToken != "" {
-		req.Header.Set("Authorization", "bearer "+ghToken)
-	}
-
 	client := &http.Client{Timeout: 15 * time.Second}
-	resp, err := client.Do(req)
+	resp, err := doGitHubWithTokenRotation(client, func(token string) (*http.Request, error) {
+		req, requestErr := http.NewRequestWithContext(c.Request.Context(), "POST", "https://api.github.com/graphql", bytes.NewReader(jsonBody))
+		if requestErr != nil {
+			return nil, requestErr
+		}
+		req.Header.Set("Content-Type", "application/json")
+		if token != "" {
+			req.Header.Set("Authorization", "bearer "+token)
+		}
+		return req, nil
+	}, "")
 	if err != nil {
 		c.JSON(http.StatusBadGateway, gin.H{"error": "github unreachable"})
 		return
@@ -3186,6 +3216,57 @@ func CodebergProxyHandler(c *gin.Context) {
 	}
 }
 
+func GitLabProxyHandler(c *gin.Context) {
+	if c.Request.Method != http.MethodGet && c.Request.Method != http.MethodHead {
+		c.AbortWithStatusJSON(http.StatusMethodNotAllowed, gin.H{"error": "only GET/HEAD allowed"})
+		return
+	}
+
+	escapedPath := c.Request.URL.EscapedPath()
+	if c.Request.URL.RawPath != "" {
+		escapedPath = c.Request.URL.RawPath
+	}
+	path := strings.TrimPrefix(escapedPath, "/api/gl-proxy/")
+	if path == "" || strings.Contains(path, "..") || (!strings.HasPrefix(path, "api/v4/") && !strings.Contains(path, "/-/raw/")) {
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid GitLab API path"})
+		return
+	}
+
+	target := "https://gitlab.com/" + path
+	if c.Request.URL.RawQuery != "" {
+		target += "?" + c.Request.URL.RawQuery
+	}
+	req, err := http.NewRequestWithContext(c.Request.Context(), c.Request.Method, target, nil)
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to build request"})
+		return
+	}
+	if token := os.Getenv("GITLAB_TOKEN"); token != "" {
+		req.Header.Set("PRIVATE-TOKEN", token)
+	} else if auth := c.GetHeader("Authorization"); auth != "" {
+		req.Header.Set("PRIVATE-TOKEN", strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(auth, "token "), "Bearer ")))
+	}
+	req.Header.Set("Accept", c.GetHeader("Accept"))
+	req.Header.Set("User-Agent", "gitGost/1.0")
+
+	resp, err := (&http.Client{Timeout: 45 * time.Second}).Do(req)
+	if err != nil {
+		utils.Log("GitLab proxy error: %v", err)
+		c.AbortWithStatusJSON(http.StatusBadGateway, gin.H{"error": "failed to reach GitLab"})
+		return
+	}
+	defer resp.Body.Close()
+	for _, header := range []string{"Content-Type", "Cache-Control", "ETag", "Link", "X-Total", "X-Total-Pages", "X-Page", "X-Per-Page"} {
+		if value := resp.Header.Get(header); value != "" {
+			c.Writer.Header().Set(header, value)
+		}
+	}
+	c.Writer.WriteHeader(resp.StatusCode)
+	if _, err := io.Copy(c.Writer, resp.Body); err != nil {
+		utils.Log("GitLab proxy copy error: %v", err)
+	}
+}
+
 // GitHubAPIProxyHandler keeps browser requests to api.github.com on the server.
 func GitHubAPIProxyHandler(c *gin.Context) {
 	path := strings.TrimPrefix(c.Request.URL.Path, "/api/gh-proxy/")
@@ -3198,23 +3279,19 @@ func GitHubAPIProxyHandler(c *gin.Context) {
 	if c.Request.URL.RawQuery != "" {
 		target += "?" + c.Request.URL.RawQuery
 	}
-	req, err := http.NewRequestWithContext(c.Request.Context(), c.Request.Method, target, nil)
-	if err != nil {
-		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "failed to build request"})
-		return
-	}
-
-	token := tokenpool.NextGitHubToken()
-	if token == "" {
-		token = strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(c.GetHeader("Authorization"), "token "), "Bearer "))
-	}
-	if token != "" {
-		req.Header.Set("Authorization", "token "+token)
-	}
-	req.Header.Set("Accept", c.GetHeader("Accept"))
-	req.Header.Set("User-Agent", "gitGost")
-
-	resp, err := (&http.Client{Timeout: 15 * time.Second}).Do(req)
+	fallbackToken := strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(c.GetHeader("Authorization"), "token "), "Bearer "))
+	resp, err := doGitHubWithTokenRotation(&http.Client{Timeout: 15 * time.Second}, func(token string) (*http.Request, error) {
+		req, requestErr := http.NewRequestWithContext(c.Request.Context(), c.Request.Method, target, nil)
+		if requestErr != nil {
+			return nil, requestErr
+		}
+		if token != "" {
+			req.Header.Set("Authorization", "token "+token)
+		}
+		req.Header.Set("Accept", c.GetHeader("Accept"))
+		req.Header.Set("User-Agent", "gitGost")
+		return req, nil
+	}, fallbackToken)
 	if err != nil {
 		utils.Log("GitHub API proxy error: %v", err)
 		c.AbortWithStatusJSON(http.StatusBadGateway, gin.H{"error": "failed to reach GitHub"})

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -313,6 +313,7 @@ func SetupRouter(cfg *config.Config) *gin.Engine {
 		api.GET("/gh-proxy/*path", prCheckLimiter(), GitHubAPIProxyHandler)
 		api.GET("/trending/:provider", TrendingHandler)
 		api.GET("/cb-proxy/*path", prCheckLimiter(), CodebergProxyHandler)
+		api.GET("/gl-proxy/*path", prCheckLimiter(), GitLabProxyHandler)
 		api.GET("/gl-notes/:owner/:repo/:number", GitLabIssueNotesProxyHandler)
 		api.GET("/gl-commit-count/:owner/:repo", GitLabCommitCountHandler)
 		api.GET("/gl-avatar", GitLabAvatarHandler)

--- a/web/profile.html
+++ b/web/profile.html
@@ -128,7 +128,7 @@
             display: flex;
             align-items: center;
             gap: 0.55rem;
-            padding: 0.45rem 1rem;
+            padding: 0.65rem 1rem;
             color: var(--fg-muted);
             text-decoration: none;
             font-size: 0.8rem;
@@ -145,7 +145,6 @@
             flex: 1;
             min-width: 0;
             padding: 1.5rem 2rem;
-            max-width: 860px;
         }
 
         .right-sidebar {
@@ -715,6 +714,23 @@
             return window.location.origin;
         }
         const API_BASE = getApiBase();
+
+        const nativeFetch = window.fetch.bind(window);
+        function proxiedProviderFetch(input, opts = {}) {
+            const target = new URL(typeof input === 'string' ? input : input.url, window.location.href);
+            let proxyPath = '';
+            if (target.hostname === 'gitlab.com' && (target.pathname.startsWith('/api/v4/') || target.pathname.includes('/-/raw/'))) {
+                proxyPath = '/api/gl-proxy' + target.pathname;
+            } else if (target.hostname === 'codeberg.org' && (target.pathname.startsWith('/api/v1/') || target.pathname.includes('/raw/branch/'))) {
+                proxyPath = '/api/cb-proxy' + target.pathname;
+            }
+            if (proxyPath) {
+                const proxyURL = new URL(proxyPath + target.search, API_BASE);
+                return nativeFetch(proxyURL, opts);
+            }
+            return nativeFetch(input, opts);
+        }
+        window.fetch = proxiedProviderFetch;
 
         // Ruta limpia: /gh|gl|cb/{username}
         const _pathParts = window.location.pathname.split('/').filter(Boolean);

--- a/web/repo.html
+++ b/web/repo.html
@@ -406,7 +406,6 @@
             font-size: 0.9rem;
             line-height: 1.75;
             color: var(--fg);
-            max-width: 860px;
             /* Parte URLs largas, fingerprints, permisos y tablas en vez de desbordar el panel. */
             overflow-wrap: anywhere;
         }
@@ -530,7 +529,7 @@
         }
         .left-nav a {
             display: block;
-            padding: 0.35rem 1rem;
+            padding: 0.65rem 1rem;
             font-size: 0.78rem;
             font-family: "IBM Plex Mono", monospace;
             color: var(--fg-muted);
@@ -2733,6 +2732,23 @@
             return window.location.origin;
         }
         const API_BASE = getApiBase();
+
+        const nativeFetch = window.fetch.bind(window);
+        function proxiedProviderFetch(input, opts = {}) {
+            const target = new URL(typeof input === 'string' ? input : input.url, window.location.href);
+            let proxyPath = '';
+            if (target.hostname === 'gitlab.com' && (target.pathname.startsWith('/api/v4/') || target.pathname.includes('/-/raw/'))) {
+                proxyPath = '/api/gl-proxy' + target.pathname;
+            } else if (target.hostname === 'codeberg.org' && (target.pathname.startsWith('/api/v1/') || target.pathname.includes('/raw/branch/'))) {
+                proxyPath = '/api/cb-proxy' + target.pathname;
+            }
+            if (proxyPath) {
+                const proxyURL = new URL(proxyPath + target.search, API_BASE);
+                return nativeFetch(proxyURL, opts);
+            }
+            return nativeFetch(input, opts);
+        }
+        window.fetch = proxiedProviderFetch;
 
         async function checkServiceStatus() {
             try {


### PR DESCRIPTION
Introduce GitHub token rotation logic and add a GitLab API proxy. handlers.go: add doGitHubWithTokenRotation, use it for GitHub API and Discussions proxying (falls back to client-provided token), and implement GitLabProxyHandler (validates paths, forwards PRIVATE-TOKEN or Authorization, and copies response headers). router.go: register /gl-proxy route. web/profile.html & web/repo.html: adjust sidebar padding/max-width and inject proxiedProviderFetch to route gitlab.com/codeberg.org API/raw calls through server proxies. internal/http/github_proxy_test.go: add tests for GitHub token rotation and GitLab proxy. Minor formatting and error handling improvements.